### PR TITLE
Add instruction cycle timing

### DIFF
--- a/soft65c02_lib/src/cpu_instruction/cpu_instruction.rs
+++ b/soft65c02_lib/src/cpu_instruction/cpu_instruction.rs
@@ -3,6 +3,29 @@ use crate::addressing_mode::*;
 use crate::memory::MemoryStack as Memory;
 use crate::registers::Registers;
 use std::fmt;
+use std::cell::Cell;
+
+/// Cycle timings for the 65C02 instructions
+/// Values taken from Symon emulator's CMOS timing table
+/// https://raw.githubusercontent.com/sethm/symon/refs/heads/master/src/main/java/com/loomcom/symon/InstructionTable.java
+const INSTRUCTION_CYCLES: [u8; 256] = [
+    7, 6, 2, 1, 5, 3, 5, 5, 3, 2, 2, 1, 6, 4, 6, 5, // 0x00-0x0f
+    2, 5, 5, 1, 5, 4, 6, 5, 2, 4, 2, 1, 6, 4, 6, 5, // 0x10-0x1f
+    6, 6, 2, 1, 3, 3, 5, 5, 4, 2, 2, 1, 4, 4, 6, 5, // 0x20-0x2f
+    2, 5, 5, 1, 4, 4, 6, 5, 2, 4, 2, 1, 4, 4, 6, 5, // 0x30-0x3f
+    6, 6, 2, 1, 2, 3, 5, 3, 3, 2, 2, 1, 3, 4, 6, 5, // 0x40-0x4f
+    2, 5, 5, 1, 4, 4, 6, 5, 2, 4, 3, 1, 8, 4, 6, 5, // 0x50-0x5f
+    6, 6, 2, 1, 3, 3, 5, 5, 4, 2, 2, 1, 6, 4, 6, 5, // 0x60-0x6f
+    2, 5, 5, 1, 4, 4, 6, 5, 2, 4, 4, 3, 6, 4, 6, 5, // 0x70-0x7f
+    3, 6, 2, 1, 3, 3, 3, 5, 2, 2, 2, 1, 4, 4, 4, 5, // 0x80-0x8f
+    2, 6, 5, 1, 4, 4, 4, 5, 2, 5, 2, 1, 4, 5, 5, 5, // 0x90-0x9f
+    2, 6, 2, 1, 3, 3, 3, 5, 2, 2, 2, 1, 4, 4, 4, 5, // 0xa0-0xaf
+    2, 5, 5, 1, 4, 4, 4, 5, 2, 4, 2, 1, 4, 4, 4, 5, // 0xb0-0xbf
+    2, 6, 2, 1, 3, 3, 5, 5, 2, 2, 2, 3, 4, 4, 6, 5, // 0xc0-0xcf
+    2, 5, 5, 1, 4, 4, 6, 5, 2, 4, 3, 3, 4, 4, 7, 5, // 0xd0-0xdf
+    2, 6, 2, 1, 3, 3, 5, 5, 2, 2, 2, 1, 4, 4, 6, 5, // 0xe0-0xef
+    2, 5, 5, 1, 4, 4, 6, 5, 2, 4, 4, 1, 4, 4, 7, 5  // 0xf0-0xff
+];
 
 pub type BoxedMicrocode =
     Box<dyn Fn(&mut Memory, &mut Registers, &CPUInstruction) -> MicrocodeResult<LogLine>>;
@@ -12,6 +35,7 @@ pub struct CPUInstruction {
     pub mnemonic: String,
     pub addressing_mode: AddressingMode,
     pub microcode: BoxedMicrocode,
+    pub cycles: Cell<u8>,
 }
 
 impl CPUInstruction {
@@ -29,6 +53,7 @@ impl CPUInstruction {
             mnemonic: mnemonic.to_owned(),
             addressing_mode,
             microcode: Box::new(microcode),
+            cycles: Cell::new(INSTRUCTION_CYCLES[opcode as usize]),
         }
     }
 
@@ -38,6 +63,30 @@ impl CPUInstruction {
         registers: &mut Registers,
     ) -> MicrocodeResult<LogLine> {
         (self.microcode)(memory, registers, self)
+    }
+
+    // Add branch cycles based on whether branch was taken and page boundary crossed
+    pub fn add_branch_cycles(&self, registers: &Registers, original_cp: usize) {
+        if let AddressingMode::Relative(_, _) = self.addressing_mode {
+            let next_instruction = original_cp + 2;
+            
+            // If branch was taken (command pointer changed from next instruction)
+            if registers.command_pointer != next_instruction {
+                // Add one cycle for taken branch
+                self.cycles.set(self.cycles.get() + 1);
+                
+                // Add another cycle if page boundary crossed
+                if next_instruction & 0xFF00 != registers.command_pointer & 0xFF00 {
+                    self.cycles.set(self.cycles.get() + 1);
+                }
+            }
+        }
+    }
+
+    pub fn adjust_base_cycles(&self, registers: &Registers, memory: &Memory) {
+        if self.addressing_mode.needs_page_crossing_cycle(registers, memory) {
+            self.cycles.set(self.cycles.get() + 1);
+        }
     }
 }
 
@@ -71,6 +120,7 @@ pub struct LogLine {
     pub mnemonic: String,
     pub resolution: AddressingModeResolution,
     pub outcome: String,
+    pub cycles: u8,
 }
 
 impl LogLine {
@@ -85,6 +135,7 @@ impl LogLine {
             mnemonic: cpu_instruction.mnemonic.clone(),
             resolution,
             outcome,
+            cycles: cpu_instruction.cycles.get(),
         }
     }
 }
@@ -105,8 +156,8 @@ impl fmt::Display for LogLine {
 
         write!(
             f,
-            "#0x{:04X}: {: <14}{: <4} {: <15}  {}",
-            self.address, byte_sequence, self.mnemonic, self.resolution, self.outcome
+            "#0x{:04X}: {: <14}{: <4} {: <15}  {}[{}]",
+            self.address, byte_sequence, self.mnemonic, self.resolution, self.outcome, self.cycles
         )
     }
 }
@@ -115,6 +166,7 @@ impl fmt::Display for LogLine {
 pub mod tests {
     use super::*;
     use crate::memory::AddressableIO;
+    use crate::processing_unit::resolve_opcode;
 
     pub fn get_stuff(addr: usize, program: Vec<u8>) -> (Memory, Registers) {
         let mut memory = Memory::new_with_ram();
@@ -122,5 +174,35 @@ pub mod tests {
         let registers = Registers::new_initialized(addr);
 
         (memory, registers)
+    }
+
+    #[test]
+    fn test_instruction_cycles() {
+        let mut memory = Memory::new_with_ram();
+        
+        // Write test instructions to memory
+        memory.write(0x1000, &[0xa9, 0x00]).unwrap(); // LDA #$nn
+        let lda_imm = resolve_opcode(0x1000, 0xa9, &memory).unwrap();
+        assert_eq!(lda_imm.cycles.get(), 2, "LDA immediate should take 2 cycles");
+
+        memory.write(0x1000, &[0x8d, 0x00, 0x20]).unwrap(); // STA $nnnn
+        let sta_abs = resolve_opcode(0x1000, 0x8d, &memory).unwrap();
+        assert_eq!(sta_abs.cycles.get(), 4, "STA absolute should take 4 cycles");
+
+        memory.write(0x1000, &[0x20, 0x00, 0x20]).unwrap(); // JSR $nnnn
+        let jsr_abs = resolve_opcode(0x1000, 0x20, &memory).unwrap();
+        assert_eq!(jsr_abs.cycles.get(), 6, "JSR absolute should take 6 cycles");
+
+        memory.write(0x1000, &[0x60]).unwrap(); // RTS implied
+        let rts = resolve_opcode(0x1000, 0x60, &memory).unwrap();
+        assert_eq!(rts.cycles.get(), 6, "RTS should take 6 cycles");
+
+        memory.write(0x1000, &[0x00]).unwrap(); // BRK implied
+        let brk = resolve_opcode(0x1000, 0x00, &memory).unwrap();
+        assert_eq!(brk.cycles.get(), 7, "BRK should take 7 cycles");
+
+        memory.write(0x1000, &[0xdb]).unwrap(); // STP implied
+        let stp = resolve_opcode(0x1000, 0xdb, &memory).unwrap();
+        assert_eq!(stp.cycles.get(), 3, "STP should take 3 cycles");
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/and.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/and.rs
@@ -18,6 +18,9 @@ pub fn and(
         .target_address
         .expect("AND must have operands, crashing the application");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     let byte = memory.read(target_address, 1)?[0];
     registers.accumulator &= byte;
     registers.set_z_flag(registers.accumulator == 0);
@@ -28,7 +31,8 @@ pub fn and(
         cpu_instruction,
         resolution,
         format!(
-            "[A=0x{:02x}][S={}]",
+            "(0x{:02x})[A=0x{:02x}][S={}]",
+            byte,
             registers.accumulator,
             registers.format_status()
         ),
@@ -41,9 +45,9 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_and() {
+    fn test_and_immediate() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "AND", AddressingMode::Immediate([0x0a]), and);
+            CPUInstruction::new(0x1000, 0x29, "AND", AddressingMode::Immediate([0x0a]), and);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x00, 0x0a, 0x02]);
         registers.accumulator = 0x22;
         let log_line = cpu_instruction
@@ -54,33 +58,105 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (29 0a)       AND  #$0a     (#0x1001)  (0x0a)[A=0x02][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_and_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x3D, "AND", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), and);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3D, 0xFF, 0x10]);
+        registers.register_x = 0x01;
+        registers.accumulator = 0x22;
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x02, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Absolute,X with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (3d ff 10)    AND  $10FF,X  (#0x1100)  (0x0a)[A=0x02][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_and_absolute_x_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x3D, "AND", AddressingMode::AbsoluteXIndexed([0x50, 0x10]), and);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3D, 0x50, 0x10]);
+        registers.register_x = 0x01;
+        registers.accumulator = 0x22;
+        memory.write(0x1051, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x02, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Absolute,X without page cross: 4 cycles
+        assert_eq!("#0x1000: (3d 50 10)    AND  $1050,X  (#0x1051)  (0x0a)[A=0x02][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_and_indirect_y_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x31, "AND", AddressingMode::ZeroPageIndirectYIndexed([0x20]), and);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x31, 0x20]);
+        registers.register_y = 0x01;
+        registers.accumulator = 0x22;
+        memory.write(0x20, &[0xFF, 0x10]).unwrap();
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x02, registers.accumulator);
+        assert_eq!(6, log_line.cycles); // Indirect,Y with page cross: 5 + 1 cycles
+        assert_eq!("#0x1000: (31 20)       AND  ($20),Y  (#0x1100)  (0x0a)[A=0x02][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_and_indirect_y_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x31, "AND", AddressingMode::ZeroPageIndirectYIndexed([0x20]), and);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x31, 0x20]);
+        registers.register_y = 0x01;
+        registers.accumulator = 0x22;
+        memory.write(0x20, &[0x50, 0x10]).unwrap();
+        memory.write(0x1051, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x02, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Indirect,Y without page cross: 5 cycles
+        assert_eq!("#0x1000: (31 20)       AND  ($20),Y  (#0x1051)  (0x0a)[A=0x02][S=nv-Bdizc][5]", log_line.to_string());
     }
 
     #[test]
     fn test_and_set_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "AND", AddressingMode::Immediate([0x55]), and);
+            CPUInstruction::new(0x1000, 0x29, "AND", AddressingMode::Immediate([0x55]), and);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x55, 0x02]);
         registers.accumulator = 0xaa;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (29 55)       AND  #$55     (#0x1001)  (0x55)[A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_and_set_negative() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "AND", AddressingMode::Immediate([0xaa]), and);
+            CPUInstruction::new(0x1000, 0x29, "AND", AddressingMode::Immediate([0xaa]), and);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0xaa]);
         registers.accumulator = 0xd5;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x80, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (29 aa)       AND  #$aa     (#0x1001)  (0xaa)[A=0x80][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/asl.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/asl.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+/// # ASL - Arithmetic Shift Left
+///
+/// On the 65C02 (unlike the 6502):
+/// - ASL absolute,X takes 6 cycles when no page boundary is crossed
+/// - ASL absolute,X takes 7 cycles when a page boundary is crossed
+/// - On the 6502, ASL absolute,X always takes 7 cycles regardless of page crossing
+///
+/// This implementation follows the 65C02 behavior.
+/// See http://www.6502.org/tutorials/65c02opcodes.html
 pub fn asl(
     memory: &mut Memory,
     registers: &mut Registers,
@@ -9,6 +18,9 @@ pub fn asl(
         cpu_instruction
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
+
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
 
     let byte = match resolution.target_address {
         Some(addr) => memory.read(addr, 1)?[0],
@@ -43,8 +55,8 @@ mod tests {
     #[test]
     fn test_asl() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ASL", AddressingMode::ZeroPage([0x0a]), asl);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x06, "ASL", AddressingMode::ZeroPage([0x0a]), asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x06, 0x0a]);
         memory.write(0x0a, &[0x28]).unwrap();
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -55,66 +67,142 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // Zero Page: 5 cycles
+        assert_eq!("#0x1000: (06 0a)       ASL  $0a      (#0x000A)  0x50[S=nv-Bdizc][5]", log_line.to_string());
     }
 
     #[test]
     fn test_asl_acc() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ASL", AddressingMode::Accumulator, asl);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x0A, "ASL", AddressingMode::Accumulator, asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0A]);
         registers.accumulator = 0x28;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x50, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
-        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (0a)          ASL  A                   [A=0x50][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_asl_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x1E, "ASL", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1E, 0xFF, 0x10]);
+        registers.register_x = 0x01; // This will cause page crossing: $10FF + $01 = $1100
+        memory.write(0x1100, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x50, memory.read(0x1100, 1).unwrap()[0]);
+        assert_eq!(7, log_line.cycles); // Absolute,X: 6 cycles + 1 for page crossing
+        assert_eq!("#0x1000: (1e ff 10)    ASL  $10FF,X  (#0x1100)  0x50[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_asl_absolute_x_without_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x1E, "ASL", AddressingMode::AbsoluteXIndexed([0x80, 0x10]), asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1E, 0x80, 0x10]);
+        registers.register_x = 0x01; // No page crossing: $1080 + $01 = $1081
+        memory.write(0x1081, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x50, memory.read(0x1081, 1).unwrap()[0]);
+        assert_eq!(6, log_line.cycles); // Absolute,X: 6 cycles (no page crossing)
+        assert_eq!("#0x1000: (1e 80 10)    ASL  $1080,X  (#0x1081)  0x50[S=nv-Bdizc][6]", log_line.to_string());
     }
 
     #[test]
     fn test_asl_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ASL", AddressingMode::Accumulator, asl);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x0A, "ASL", AddressingMode::Accumulator, asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0A]);
         registers.accumulator = 0x00;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (0a)          ASL  A                   [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_asl_with_c_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ASL", AddressingMode::Accumulator, asl);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x0A, "ASL", AddressingMode::Accumulator, asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0A]);
         registers.accumulator = 0x81;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x02, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (0a)          ASL  A                   [A=0x02][S=nv-BdizC][2]", log_line.to_string());
     }
 
     #[test]
     fn test_asl_with_n_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ASL", AddressingMode::Accumulator, asl);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x0A, "ASL", AddressingMode::Accumulator, asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0A]);
         registers.accumulator = 0x47;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x8e, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (0a)          ASL  A                   [A=0x8e][S=Nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_asl_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x0E, "ASL", AddressingMode::Absolute([0x00, 0x20]), asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0E, 0x00, 0x20]);
+        memory.write(0x2000, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x50, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (0e 00 20)    ASL  $2000    (#0x2000)  0x50[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_asl_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x16, "ASL", AddressingMode::ZeroPageXIndexed([0x20]), asl);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x16, 0x20]);
+        registers.register_x = 0x05; // Target address will be $25
+        memory.write(0x25, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x50, memory.read(0x25, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Zero Page,X: 6 cycles
+        assert_eq!("#0x1000: (16 20)       ASL  $20,X    (#0x0025)  0x50[S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bbr.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bbr.rs
@@ -12,12 +12,15 @@ pub fn bbr(
     let target_address = resolution
         .target_address
         .expect("BBR must have operands, crashing the application");
+    
+    // Test the specified bit
     let byte = memory.read(target_address, 1)?[0];
     let mut bit = 0b00000001;
     (0..cpu_instruction.opcode >> 4).for_each(|_| bit <<= 1);
 
+    // Branch if the bit is reset (0)
     if byte & bit != 0 {
-        registers.command_pointer += 1 + resolution.operands.len();
+        registers.command_pointer += 3; // Skip to next instruction (opcode + 2 operands)
     } else {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address + 1,
@@ -39,55 +42,82 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bbr0() {
+    fn test_bbr0_not_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
             0x0f,
             "BBR0",
-            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0xfe]),
+            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
             bbr,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0f, 0x0a, 0xfe]);
-        memory.write(0x000a, &[0x01]).unwrap();
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0f, 0x0a, 0x09]);
+        memory.write(0x000a, &[0x01]).unwrap(); // Set bit 0, should not branch
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BBR0".to_owned(), log_line.mnemonic);
         assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBR always takes 5 cycles
+        assert_eq!("#0x1000: (0f 0a 09)    BBR0 $0a,$100B(#0x000A)  [CP=0x1003][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_bbr7() {
+    fn test_bbr0_branching() {
+        let cpu_instruction = CPUInstruction::new(
+            0x1000,
+            0x0f,
+            "BBR0",
+            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
+            bbr,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0f, 0x0a, 0x09]);
+        memory.write(0x000a, &[0xfe]).unwrap(); // Clear bit 0, should branch
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("BBR0".to_owned(), log_line.mnemonic);
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBR always takes 5 cycles
+        assert_eq!("#0x1000: (0f 0a 09)    BBR0 $0a,$100B(#0x000A)  [CP=0x100C][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bbr7_not_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
             0x7f,
             "BBR7",
-            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0xfe]),
+            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
             bbr,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7f, 0x0a, 0xfe]);
-        memory.write(0x000a, &[0x80]).unwrap();
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7f, 0x0a, 0x09]);
+        memory.write(0x000a, &[0x80]).unwrap(); // Set bit 7, should not branch
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BBR7".to_owned(), log_line.mnemonic);
         assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBR always takes 5 cycles
+        assert_eq!("#0x1000: (7f 0a 09)    BBR7 $0a,$100B(#0x000A)  [CP=0x1003][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_branching_bbr3() {
+    fn test_bbr7_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0x3f,
-            "BBR3",
+            0x7f,
+            "BBR7",
             AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
             bbr,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3f, 0x0a, 0x09]);
-        memory.write(0x000a, &[0xf7]).unwrap();
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7f, 0x0a, 0x09]);
+        memory.write(0x000a, &[0x7f]).unwrap(); // Clear bit 7, should branch
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
+        assert_eq!("BBR7".to_owned(), log_line.mnemonic);
         assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBR always takes 5 cycles
+        assert_eq!("#0x1000: (7f 0a 09)    BBR7 $0a,$100B(#0x000A)  [CP=0x100C][5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bbs.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bbs.rs
@@ -12,12 +12,15 @@ pub fn bbs(
     let target_address = resolution
         .target_address
         .expect("BBS must have operands, crashing the application");
+    
+    // Test the specified bit
     let byte = memory.read(target_address, 1)?[0];
     let mut bit = 0b00000001;
     (0..(cpu_instruction.opcode >> 4) - 8).for_each(|_| bit <<= 1);
 
+    // Branch if the bit is set (1)
     if byte & bit == 0 {
-        registers.command_pointer += 1 + resolution.operands.len();
+        registers.command_pointer += 3; // Skip to next instruction (opcode + 2 operands)
     } else {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address + 1,
@@ -39,55 +42,82 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bbs0() {
+    fn test_bbs0_not_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
             0x8f,
             "BBS0",
-            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0xfe]),
+            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
             bbs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8f, 0x0a, 0xfe]);
-        memory.write(0x000a, &[0xfe]).unwrap();
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8f, 0x0a, 0x09]);
+        memory.write(0x000a, &[0xfe]).unwrap(); // Clear bit 0, should not branch
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BBS0".to_owned(), log_line.mnemonic);
         assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBS always takes 5 cycles
+        assert_eq!("#0x1000: (8f 0a 09)    BBS0 $0a,$100B(#0x000A)  [CP=0x1003][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_bbs7() {
+    fn test_bbs0_branching() {
+        let cpu_instruction = CPUInstruction::new(
+            0x1000,
+            0x8f,
+            "BBS0",
+            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
+            bbs,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8f, 0x0a, 0x09]);
+        memory.write(0x000a, &[0x01]).unwrap(); // Set bit 0, should branch
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("BBS0".to_owned(), log_line.mnemonic);
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBS always takes 5 cycles
+        assert_eq!("#0x1000: (8f 0a 09)    BBS0 $0a,$100B(#0x000A)  [CP=0x100C][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bbs7_not_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
             0xff,
             "BBS7",
-            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0xfe]),
+            AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
             bbs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xff, 0x0a, 0xfe]);
-        memory.write(0x000a, &[0x7f]).unwrap();
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xff, 0x0a, 0x09]);
+        memory.write(0x000a, &[0x7f]).unwrap(); // Clear bit 7, should not branch
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BBS7".to_owned(), log_line.mnemonic);
         assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBS always takes 5 cycles
+        assert_eq!("#0x1000: (ff 0a 09)    BBS7 $0a,$100B(#0x000A)  [CP=0x1003][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_branching_bbs3() {
+    fn test_bbs7_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xbf,
-            "BBS3",
+            0xff,
+            "BBS7",
             AddressingMode::ZeroPageRelative(0x1000, [0x0a, 0x09]),
             bbs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xbf, 0x0a, 0x09]);
-        memory.write(0x000a, &[0x08]).unwrap();
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xff, 0x0a, 0x09]);
+        memory.write(0x000a, &[0x80]).unwrap(); // Set bit 7, should branch
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
+        assert_eq!("BBS7".to_owned(), log_line.mnemonic);
         assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // BBS always takes 5 cycles
+        assert_eq!("#0x1000: (ff 0a 09)    BBS7 $0a,$100B(#0x000A)  [CP=0x100C][5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bcc.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bcc.rs
@@ -10,6 +10,8 @@ pub fn bcc(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.c_flag_is_set() {
         registers.command_pointer += 1 + resolution.operands.len();
     } else {
@@ -18,6 +20,9 @@ pub fn bcc(
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BCC");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     }
 
     Ok(LogLine::new(
@@ -33,15 +38,15 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bcc() {
+    fn test_bcc_not_branching() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x90,
             "BCC",
             AddressingMode::Relative(0x1000, [0x0a]),
             bcc,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x90, 0x0a]);
         registers.set_c_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -49,23 +54,47 @@ mod tests {
         assert_eq!("BCC".to_owned(), log_line.mnemonic);
         assert!(registers.c_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (90 0a)       BCC  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bcc_with_c_clear() {
+    fn test_bcc_branching_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x90,
             "BCC",
             AddressingMode::Relative(0x1000, [0x0a]),
             bcc,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x90, 0x0a]);
         registers.set_c_flag(false);
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(!registers.c_flag_is_set());
         assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, log_line.cycles);
+        assert_eq!("#0x1000: (90 0a)       BCC  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bcc_branching_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0x90,
+            "BCC",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bcc,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0x90, 0x20]);
+        registers.set_c_flag(false);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, log_line.cycles);
+        assert_eq!("#0x10F0: (90 20)       BCC  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bcs.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bcs.rs
@@ -10,14 +10,19 @@ pub fn bcs(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.c_flag_is_set() {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address,
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BCS");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     } else {
-        registers.command_pointer += 1 + resolution.operands.len();
+        registers.command_pointer += 2;
     }
 
     Ok(LogLine::new(
@@ -33,39 +38,64 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bcs() {
+    fn test_bcs_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0xb0,
             "BCS",
             AddressingMode::Relative(0x1000, [0x0a]),
             bcs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.set_c_flag(true);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xb0, 0x0a]);
+        registers.set_c_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BCS".to_owned(), log_line.mnemonic);
-        assert!(registers.c_flag_is_set());
-        assert_eq!(0x100c, registers.command_pointer);
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BCS not taken should take 2 cycles");
+        assert_eq!("#0x1000: (b0 0a)       BCS  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bcs_with_c_clear() {
+    fn test_bcs_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0xb0,
             "BCS",
             AddressingMode::Relative(0x1000, [0x0a]),
             bcs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.set_c_flag(false);
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xb0, 0x0a]);
+        registers.set_c_flag(true);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert!(!registers.c_flag_is_set());
-        assert_eq!(0x1002, registers.command_pointer);
+        assert!(registers.c_flag_is_set());
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BCS taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (b0 0a)       BCS  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bcs_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0xb0,
+            "BCS",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bcs,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0xb0, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_c_flag(true);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(registers.c_flag_is_set());
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BCS taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (b0 20)       BCS  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/beq.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/beq.rs
@@ -10,12 +10,17 @@ pub fn beq(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.z_flag_is_set() {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address,
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BEQ");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     } else {
         registers.command_pointer += 2;
     }
@@ -33,37 +38,61 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_beq_branch() {
+    fn test_beq_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0xf0,
             "BEQ",
             AddressingMode::Relative(0x1000, [0x0a]),
             beq,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xf0, 0x0a]);
         registers.set_z_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BEQ".to_owned(), log_line.mnemonic);
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BEQ not taken should take 2 cycles");
+        assert_eq!("#0x1000: (f0 0a)       BEQ  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_beq_no_branch() {
+    fn test_beq_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0xf0,
             "BEQ",
             AddressingMode::Relative(0x1000, [0x0a]),
             beq,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xf0, 0x0a]);
         registers.set_z_flag(true);
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BEQ taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (f0 0a)       BEQ  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_beq_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0xf0,
+            "BEQ",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            beq,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0xf0, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_z_flag(true);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BEQ taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (f0 20)       BEQ  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bit.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bit.rs
@@ -13,6 +13,9 @@ pub fn bit(
         .target_address
         .expect("BIT must have operands, crashing the application");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     let byte = memory.read(target_address, 1)?[0];
     registers.set_z_flag(registers.accumulator & byte == 0);
 
@@ -31,7 +34,12 @@ pub fn bit(
     Ok(LogLine::new(
         cpu_instruction,
         resolution,
-        format!("[S={}]", registers.format_status()),
+        format!(
+            "(0x{:02x})[A=0x{:02x}][S={}]",
+            byte,
+            registers.accumulator,
+            registers.format_status()
+        ),
     ))
 }
 
@@ -43,8 +51,8 @@ mod tests {
     #[test]
     fn test_bit() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "BIT", AddressingMode::Immediate([0x0a]), bit);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x89, "BIT", AddressingMode::Immediate([0x0a]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x89, 0x0a]);
         registers.accumulator = 0x03;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -54,77 +62,141 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert!(!registers.v_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (89 0a)       BIT  #$0a     (#0x1001)  (0x0a)[A=0x03][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bit_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x2C, "BIT", AddressingMode::Absolute([0x00, 0x20]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x2C, 0x00, 0x20]);
+        registers.accumulator = 0x03;
+        memory.write(0x2000, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.v_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (2c 00 20)    BIT  $2000    (#0x2000)  (0x0a)[A=0x03][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bit_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x3C, "BIT", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3C, 0xFF, 0x10]);
+        registers.register_x = 0x01;
+        registers.accumulator = 0x03;
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.v_flag_is_set());
+        assert_eq!(5, log_line.cycles); // Absolute,X with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (3c ff 10)    BIT  $10FF,X  (#0x1100)  (0x0a)[A=0x03][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bit_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x24, "BIT", AddressingMode::ZeroPage([0x20]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x24, 0x20]);
+        registers.accumulator = 0x03;
+        memory.write(0x20, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.v_flag_is_set());
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (24 20)       BIT  $20      (#0x0020)  (0x0a)[A=0x03][S=nv-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_bit_negative() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "bit", AddressingMode::ZeroPage([0xa0]), bit);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0xa0, 0x02]);
+            CPUInstruction::new(0x1000, 0x24, "BIT", AddressingMode::ZeroPage([0xa0]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x24, 0xa0]);
         registers.accumulator = 0x03;
         memory.write(0xa0, &[0xba]).unwrap();
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert!(!registers.v_flag_is_set());
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (24 a0)       BIT  $a0      (#0x00A0)  (0xba)[A=0x03][S=Nv-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_bit_negative_immediate() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "bit", AddressingMode::Immediate([0xba]), bit);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0xba, 0x02]);
+            CPUInstruction::new(0x1000, 0x89, "BIT", AddressingMode::Immediate([0xba]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x89, 0xba]);
         registers.accumulator = 0x03;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.v_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (89 ba)       BIT  #$ba     (#0x1001)  (0xba)[A=0x03][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_bit_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "bit", AddressingMode::Immediate([0x03]), bit);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x03, 0x02]);
+            CPUInstruction::new(0x1000, 0x89, "BIT", AddressingMode::Immediate([0x03]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x89, 0x03]);
         registers.accumulator = 0x04;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.v_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (89 03)       BIT  #$03     (#0x1001)  (0x03)[A=0x04][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_bit_overflow() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "bit", AddressingMode::ZeroPage([0xa0]), bit);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0xa0, 0x02]);
+            CPUInstruction::new(0x1000, 0x24, "BIT", AddressingMode::ZeroPage([0xa0]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x24, 0xa0]);
         registers.accumulator = 0x03;
         memory.write(0xa0, &[0x4d]).unwrap();
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(registers.v_flag_is_set());
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (24 a0)       BIT  $a0      (#0x00A0)  (0x4d)[A=0x03][S=nV-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_bit_overflow_immediate() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "bit", AddressingMode::Immediate([0x4d]), bit);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x4d, 0x02]);
+            CPUInstruction::new(0x1000, 0x89, "BIT", AddressingMode::Immediate([0x4d]), bit);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x89, 0x4d]);
         registers.accumulator = 0x03;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.v_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (89 4d)       BIT  #$4d     (#0x1001)  (0x4d)[A=0x03][S=nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bmi.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bmi.rs
@@ -10,12 +10,17 @@ pub fn bmi(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.n_flag_is_set() {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address,
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BMI");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     } else {
         registers.command_pointer += 2;
     }
@@ -33,37 +38,61 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bmi_branch() {
+    fn test_bmi_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x30,
             "BMI",
             AddressingMode::Relative(0x1000, [0x0a]),
             bmi,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
-        registers.set_n_flag(true);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x30, 0x0a]);
+        registers.set_n_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BMI".to_owned(), log_line.mnemonic);
-        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BMI not taken should take 2 cycles");
+        assert_eq!("#0x1000: (30 0a)       BMI  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bmi_no_branch() {
+    fn test_bmi_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x30,
             "BMI",
             AddressingMode::Relative(0x1000, [0x0a]),
             bmi,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
-        registers.set_n_flag(false);
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x30, 0x0a]);
+        registers.set_n_flag(true);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BMI taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (30 0a)       BMI  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bmi_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0x30,
+            "BMI",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bmi,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0x30, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_n_flag(true);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BMI taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (30 20)       BMI  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bne.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bne.rs
@@ -10,6 +10,8 @@ pub fn bne(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.z_flag_is_set() {
         registers.command_pointer += 2;
     } else {
@@ -18,6 +20,9 @@ pub fn bne(
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BNE");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     }
 
     Ok(LogLine::new(
@@ -33,37 +38,61 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bne_branch() {
+    fn test_bne_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0xd0,
             "BNE",
             AddressingMode::Relative(0x1000, [0x0a]),
             bne,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
-        registers.set_z_flag(false);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xd0, 0x0a]);
+        registers.set_z_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BNE".to_owned(), log_line.mnemonic);
-        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BNE not taken should take 2 cycles");
+        assert_eq!("#0x1000: (d0 0a)       BNE  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bne_no_branch() {
+    fn test_bne_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0xd0,
             "BNE",
             AddressingMode::Relative(0x1000, [0x0a]),
             bne,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
-        registers.set_z_flag(true);
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xd0, 0x0a]);
+        registers.set_z_flag(false);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BNE taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (d0 0a)       BNE  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bne_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0xd0,
+            "BNE",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bne,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0xd0, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_z_flag(false);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BNE taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (d0 20)       BNE  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bpl.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bpl.rs
@@ -10,6 +10,8 @@ pub fn bpl(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.n_flag_is_set() {
         registers.command_pointer += 2;
     } else {
@@ -18,6 +20,9 @@ pub fn bpl(
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BPL");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     }
 
     Ok(LogLine::new(
@@ -33,37 +38,61 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bpl_branch() {
+    fn test_bpl_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x10,
             "BPL",
             AddressingMode::Relative(0x1000, [0x0a]),
             bpl,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
-        registers.set_n_flag(false);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x10, 0x0a]);
+        registers.set_n_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BPL".to_owned(), log_line.mnemonic);
-        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BPL not taken should take 2 cycles");
+        assert_eq!("#0x1000: (10 0a)       BPL  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bpl_no_branch() {
+    fn test_bpl_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x10,
             "BPL",
             AddressingMode::Relative(0x1000, [0x0a]),
             bpl,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
-        registers.set_n_flag(true);
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x10, 0x0a]);
+        registers.set_n_flag(false);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BPL taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (10 0a)       BPL  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bpl_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0x10,
+            "BPL",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bpl,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0x10, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_n_flag(false);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BPL taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (10 20)       BPL  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bra.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bra.rs
@@ -10,11 +10,19 @@ pub fn bra(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     registers.command_pointer = resolve_relative(
         cpu_instruction.address,
         cpu_instruction.addressing_mode.get_operands()[0],
     )
     .expect("Could not resolve relative address for BRA");
+
+    // For BRA, only add the page crossing cycle if needed
+    // The branch cycle is already included in the instruction table
+    if (original_cp + 2) & 0xFF00 != registers.command_pointer & 0xFF00 {
+        cpu_instruction.cycles.set(cpu_instruction.cycles.get() + 1);
+    }
 
     Ok(LogLine::new(
         cpu_instruction,
@@ -29,19 +37,40 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bra_branch() {
+    fn test_bra_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x80,
             "BRA",
             AddressingMode::Relative(0x1000, [0x0a]),
             bra,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x80, 0x0a]);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BRA".to_owned(), log_line.mnemonic);
         assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BRA without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (80 0a)       BRA  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bra_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0x80,
+            "BRA",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bra,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0x80, 0x20]);
+        registers.command_pointer = 0x10f0;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BRA with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (80 20)       BRA  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/brk.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/brk.rs
@@ -34,8 +34,10 @@ pub fn brk(
         cpu_instruction,
         resolution,
         format!(
-            "[CP=0x{:04X}][SP=0x{:02x}]",
-            registers.command_pointer, registers.stack_pointer
+            "[CP=0x{:04X}][SP=0x{:02x}][S={}]",
+            registers.command_pointer,
+            registers.stack_pointer,
+            registers.format_status()
         ),
     ))
 }
@@ -49,7 +51,7 @@ mod tests {
     #[test]
     fn test_brk() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "BRK", AddressingMode::Implied, brk);
+            CPUInstruction::new(0x1000, 0x00, "BRK", AddressingMode::Implied, brk);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x00]);
         memory.write(0xfffe, &[0x00, 0xf0]).unwrap();
         registers.stack_pointer = 0xff;
@@ -65,5 +67,7 @@ mod tests {
         );
         assert!(registers.i_flag_is_set());
         assert!(!registers.d_flag_is_set());
+        assert_eq!(7, log_line.cycles); // Implied: 7 cycles
+        assert_eq!("#0x1000: (00)          BRK                      [CP=0xF000][SP=0xfc][S=nv-BdIzc][7]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bvc.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bvc.rs
@@ -10,14 +10,19 @@ pub fn bvc(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.v_flag_is_set() {
-        registers.command_pointer += 1 + resolution.operands.len();
+        registers.command_pointer += 2;
     } else {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address,
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BVC");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     }
 
     Ok(LogLine::new(
@@ -33,39 +38,61 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bvc() {
+    fn test_bvc_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x50,
             "BVC",
             AddressingMode::Relative(0x1000, [0x0a]),
             bvc,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x50, 0x0a]);
         registers.set_v_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BVC".to_owned(), log_line.mnemonic);
-        assert!(registers.v_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BVC not taken should take 2 cycles");
+        assert_eq!("#0x1000: (50 0a)       BVC  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bvc_with_v_clear() {
+    fn test_bvc_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x50,
             "BVC",
             AddressingMode::Relative(0x1000, [0x0a]),
             bvc,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x50, 0x0a]);
         registers.set_v_flag(false);
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert!(!registers.v_flag_is_set());
         assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BVC taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (50 0a)       BVC  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bvc_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0x50,
+            "BVC",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bvc,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0x50, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_v_flag(false);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BVC taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (50 20)       BVC  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/bvs.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/bvs.rs
@@ -10,14 +10,19 @@ pub fn bvs(
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
 
+    let original_cp = registers.command_pointer;
+
     if registers.v_flag_is_set() {
         registers.command_pointer = resolve_relative(
             cpu_instruction.address,
             cpu_instruction.addressing_mode.get_operands()[0],
         )
         .expect("Could not resolve relative address for BVS");
+        
+        // Add cycles after we know the branch was taken
+        cpu_instruction.add_branch_cycles(registers, original_cp);
     } else {
-        registers.command_pointer += 1 + resolution.operands.len();
+        registers.command_pointer += 2;
     }
 
     Ok(LogLine::new(
@@ -33,39 +38,61 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_bvs() {
+    fn test_bvs_no_branch() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x70,
             "BVS",
             AddressingMode::Relative(0x1000, [0x0a]),
             bvs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.set_v_flag(true);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x70, 0x0a]);
+        registers.set_v_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("BVS".to_owned(), log_line.mnemonic);
-        assert!(registers.v_flag_is_set());
-        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, cpu_instruction.cycles.get(), "BVS not taken should take 2 cycles");
+        assert_eq!("#0x1000: (70 0a)       BVS  $100C               [CP=0x1002][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_bvs_with_v_clear() {
+    fn test_bvs_branch_no_page_cross() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x70,
             "BVS",
             AddressingMode::Relative(0x1000, [0x0a]),
             bvs,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.set_v_flag(false);
-        let _log_line = cpu_instruction
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x70, 0x0a]);
+        registers.set_v_flag(true);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert!(!registers.v_flag_is_set());
-        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(0x100c, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get(), "BVS taken without page cross should take 3 cycles");
+        assert_eq!("#0x1000: (70 0a)       BVS  $100C               [CP=0x100C][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_bvs_branch_page_cross() {
+        let cpu_instruction = CPUInstruction::new(
+            0x10f0,
+            0x70,
+            "BVS",
+            AddressingMode::Relative(0x10f0, [0x20]),
+            bvs,
+        );
+        let (mut memory, mut registers) = get_stuff(0x10f0, vec![0x70, 0x20]);
+        registers.command_pointer = 0x10f0;
+        registers.set_v_flag(true);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1112, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get(), "BVS taken with page cross should take 4 cycles");
+        assert_eq!("#0x10F0: (70 20)       BVS  $1112               [CP=0x1112][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/clc.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/clc.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_clc() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CLC", AddressingMode::Implied, clc);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x18, "CLC", AddressingMode::Implied, clc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x18]);
         registers.set_c_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("CLC".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(!registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // CLC takes 2 cycles
+        assert_eq!("#0x1000: (18)          CLC                      [S=nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/cld.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/cld.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_cld() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CLD", AddressingMode::Implied, cld);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xD8, "CLD", AddressingMode::Implied, cld);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xD8]);
         registers.set_d_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("CLD".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(!registers.d_flag_is_set());
+        assert_eq!(2, log_line.cycles); // CLD takes 2 cycles
+        assert_eq!("#0x1000: (d8)          CLD                      [S=nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/cli.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/cli.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_cli() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CLI", AddressingMode::Implied, cli);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x58, "CLI", AddressingMode::Implied, cli);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x58]);
         registers.set_i_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("CLI".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(!registers.i_flag_is_set());
+        assert_eq!(2, log_line.cycles); // CLI takes 2 cycles
+        assert_eq!("#0x1000: (58)          CLI                      [S=nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/clv.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/clv.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_clv() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CLV", AddressingMode::Implied, clv);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xB8, "CLV", AddressingMode::Implied, clv);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB8]);
         registers.set_v_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("CLV".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(!registers.v_flag_is_set());
+        assert_eq!(2, log_line.cycles); // CLV takes 2 cycles
+        assert_eq!("#0x1000: (b8)          CLV                      [S=nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/cmp.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/cmp.rs
@@ -13,6 +13,9 @@ pub fn cmp(
         .target_address
         .expect("cmp must have operands, crashing the application");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     let byte = memory.read(target_address, 1)?[0];
 
     registers.set_c_flag(registers.accumulator >= byte);
@@ -38,10 +41,10 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_cmp_be() {
+    fn test_cmp_immediate_greater() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CMP", AddressingMode::Immediate([0x0a]), cmp);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xC9, "CMP", AddressingMode::Immediate([0x0a]), cmp);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xC9, 0x0a]);
         registers.accumulator = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -51,33 +54,77 @@ mod tests {
         assert!(registers.c_flag_is_set());
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (c9 0a)       CMP  #$0a     (#0x1001)  (0x0a)[A=0x28][S=nv-BdizC][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_cmp_equ() {
+    fn test_cmp_zero_page_equal() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CMP", AddressingMode::Immediate([0x0a]), cmp);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xC5, "CMP", AddressingMode::ZeroPage([0x0a]), cmp);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xC5, 0x0a]);
         registers.accumulator = 0x0a;
-        let _log_line = cpu_instruction
+        memory.write(0x0a, &[0x0a]).unwrap();
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(registers.c_flag_is_set());
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (c5 0a)       CMP  $0a      (#0x000A)  (0x0a)[A=0x0a][S=nv-BdiZC][3]", log_line.to_string());
     }
 
     #[test]
-    fn test_cmp_lt() {
+    fn test_cmp_absolute_less() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "CMP", AddressingMode::Immediate([0x0a]), cmp);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xCD, "CMP", AddressingMode::Absolute([0x00, 0x20]), cmp);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xCD, 0x00, 0x20]);
         registers.accumulator = 0x01;
-        let _log_line = cpu_instruction
+        memory.write(0x2000, &[0x0a]).unwrap();
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert!(!registers.c_flag_is_set());
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (cd 00 20)    CMP  $2000    (#0x2000)  (0x0a)[A=0x01][S=Nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_cmp_absolute_x_no_boundary() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xDD, "CMP", AddressingMode::AbsoluteXIndexed([0x00, 0x20]), cmp);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xDD, 0x00, 0x20]);
+        registers.register_x = 0x05;
+        registers.accumulator = 0x28;
+        memory.write(0x2005, &[0x0a]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(registers.c_flag_is_set());
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Absolute,X: 4 cycles (no page boundary crossed)
+        assert_eq!("#0x1000: (dd 00 20)    CMP  $2000,X  (#0x2005)  (0x0a)[A=0x28][S=nv-BdizC][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_cmp_absolute_x_boundary() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xDD, "CMP", AddressingMode::AbsoluteXIndexed([0xF0, 0x20]), cmp);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xDD, 0xF0, 0x20]);
+        registers.register_x = 0x15; // Cross page boundary: 0x20F0 + 0x15 = 0x2105
+        registers.accumulator = 0x28;
+        memory.write(0x2105, &[0x0a]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert!(registers.c_flag_is_set());
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert_eq!(5, log_line.cycles); // Absolute,X: 5 cycles (page boundary crossed)
+        assert_eq!("#0x1000: (dd f0 20)    CMP  $20F0,X  (#0x2105)  (0x0a)[A=0x28][S=nv-BdizC][5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/dec.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/dec.rs
@@ -13,6 +13,7 @@ pub fn dec(
         Some(addr) => memory.read(addr, 1)?[0],
         None => registers.accumulator,
     };
+
     let (res, _) = byte.overflowing_sub(1);
 
     registers.set_z_flag(res == 0);
@@ -43,10 +44,10 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_dec() {
+    fn test_dec_accumulator() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEC", AddressingMode::Accumulator, dec);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
+            CPUInstruction::new(0x1000, 0x3A, "DEC", AddressingMode::Accumulator, dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3A]);
         registers.accumulator = 0x10;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -56,50 +57,119 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator mode: 2 cycles
+        assert_eq!("#0x1000: (3a)          DEC  A                   [A=0x0f][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_dec_memory() {
+    fn test_dec_zero_page() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEC", AddressingMode::ZeroPage([0xa0]), dec);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
-        memory.write(0xa0, &[0x10]).unwrap();
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xC6, "DEC", AddressingMode::ZeroPage([0x0a]), dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xC6, 0x0a]);
+        memory.write(0x0a, &[0x10]).unwrap();
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0x0f, memory.read(0xa0, 1).unwrap()[0]);
+        assert_eq!(0x0f, memory.read(0x0a, 1).unwrap()[0]);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // Zero page: 5 cycles
+        assert_eq!("#0x1000: (c6 0a)       DEC  $0a      (#0x000A)  0x0f[S=nv-Bdizc][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_dec_when_zero() {
+    fn test_dec_zero_page_x() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEC", AddressingMode::Accumulator, dec);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
-        registers.accumulator = 0x00;
-        registers.set_c_flag(false);
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xD6, "DEC", AddressingMode::ZeroPageXIndexed([0x20]), dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xD6, 0x20]);
+        registers.register_x = 0x05; // Target address: 0x25
+        memory.write(0x25, &[0x10]).unwrap();
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xff, registers.accumulator);
-        assert!(!registers.z_flag_is_set());
-        assert!(!registers.c_flag_is_set()); // C flag is NOT affected.
-        assert!(registers.n_flag_is_set());
+        assert_eq!(0x0f, memory.read(0x25, 1).unwrap()[0]);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Zero page X: 6 cycles
+        assert_eq!("#0x1000: (d6 20)       DEC  $20,X    (#0x0025)  0x0f[S=nv-Bdizc][6]", log_line.to_string());
     }
 
     #[test]
-    fn test_dec_when_one() {
+    fn test_dec_absolute() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEC", AddressingMode::Implied, dec);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
+            CPUInstruction::new(0x1000, 0xCE, "DEC", AddressingMode::Absolute([0x00, 0x20]), dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xCE, 0x00, 0x20]);
+        memory.write(0x2000, &[0x10]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x0f, memory.read(0x2000, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (ce 00 20)    DEC  $2000    (#0x2000)  0x0f[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_dec_absolute_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xDE, "DEC", AddressingMode::AbsoluteXIndexed([0x00, 0x20]), dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xDE, 0x00, 0x20]);
+        registers.register_x = 0x05; // Target address: 0x2005
+        memory.write(0x2005, &[0x10]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x0f, memory.read(0x2005, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(7, log_line.cycles); // Absolute X: 7 cycles
+        assert_eq!("#0x1000: (de 00 20)    DEC  $2000,X  (#0x2005)  0x0f[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_dec_absolute_x_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xDE, "DEC", AddressingMode::AbsoluteXIndexed([0xFB, 0x20]), dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xDE, 0xFB, 0x20]);
+        registers.register_x = 0x05; // Target address: 0x2100 (page cross)
+        memory.write(0x2100, &[0x10]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x0f, memory.read(0x2100, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(7, log_line.cycles); // Absolute X: 7 cycles (no extra cycle for page cross on write)
+        assert_eq!("#0x1000: (de fb 20)    DEC  $20FB,X  (#0x2100)  0x0f[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_dec_with_zero_result() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x3A, "DEC", AddressingMode::Accumulator, dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3A]);
         registers.accumulator = 0x01;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (3a)          DEC  A                   [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_dec_with_negative_result() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x3A, "DEC", AddressingMode::Accumulator, dec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x3A]);
+        registers.accumulator = 0x00;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0xFF, registers.accumulator);
+        assert!(!registers.z_flag_is_set());
+        assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (3a)          DEC  A                   [A=0xff][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/dex.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/dex.rs
@@ -37,43 +37,52 @@ mod tests {
     #[test]
     fn test_dex() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEX", AddressingMode::Implied, dex);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
+            CPUInstruction::new(0x1000, 0xCA, "DEX", AddressingMode::Implied, dex);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xCA]);
         registers.register_x = 0x10;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("DEX".to_owned(), log_line.mnemonic);
-        assert_eq!(0x0f, registers.register_x);
+        assert_eq!(0x0F, registers.register_x);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (ca)          DEX                      [X=0x0f][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_dex_when_zero() {
+    fn test_dex_with_zero_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEX", AddressingMode::Implied, dex);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
-        let _log_line = cpu_instruction
-            .execute(&mut memory, &mut registers)
-            .unwrap();
-        assert_eq!(0xff, registers.register_x);
-        assert!(!registers.z_flag_is_set());
-        assert!(registers.n_flag_is_set());
-    }
-
-    #[test]
-    fn test_dex_when_one() {
-        let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEX", AddressingMode::Implied, dex);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
+            CPUInstruction::new(0x1000, 0xCA, "DEX", AddressingMode::Implied, dex);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xCA]);
         registers.register_x = 0x01;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_x);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (ca)          DEX                      [X=0x00][S=nv-BdiZc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_dex_with_negative_result() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xCA, "DEX", AddressingMode::Implied, dex);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xCA]);
+        registers.register_x = 0x00;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0xFF, registers.register_x);
+        assert!(!registers.z_flag_is_set());
+        assert!(registers.n_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (ca)          DEX                      [X=0xff][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/dey.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/dey.rs
@@ -37,45 +37,54 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_dex() {
+    fn test_dey() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEY", AddressingMode::Implied, dey);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
+            CPUInstruction::new(0x1000, 0x88, "DEY", AddressingMode::Implied, dey);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x88]);
         registers.register_y = 0x10;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("DEY".to_owned(), log_line.mnemonic);
-        assert_eq!(0x0f, registers.register_y);
+        assert_eq!(0x0F, registers.register_y);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // DEY takes 2 cycles
+        assert_eq!("#0x1000: (88)          DEY                      [Y=0x0f][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_dex_when_zero() {
+    fn test_dey_with_zero_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEY", AddressingMode::Implied, dey);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
-        let _log_line = cpu_instruction
-            .execute(&mut memory, &mut registers)
-            .unwrap();
-        assert_eq!(0xff, registers.register_y);
-        assert!(!registers.z_flag_is_set());
-        assert!(registers.n_flag_is_set());
-    }
-
-    #[test]
-    fn test_dex_when_one() {
-        let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "DEY", AddressingMode::Implied, dey);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xca, 0x0a]);
+            CPUInstruction::new(0x1000, 0x88, "DEY", AddressingMode::Implied, dey);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x88]);
         registers.register_y = 0x01;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_y);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (88)          DEY                      [Y=0x00][S=nv-BdiZc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_dey_with_negative_result() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x88, "DEY", AddressingMode::Implied, dey);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x88]);
+        registers.register_y = 0x00;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0xFF, registers.register_y);
+        assert!(!registers.z_flag_is_set());
+        assert!(registers.n_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (88)          DEY                      [Y=0xff][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/eor.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/eor.rs
@@ -13,6 +13,9 @@ pub fn eor(
         .target_address
         .expect("No operand given to EOR instruction, crashing application.");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     let byte = memory.read(target_address, 1)?[0];
     registers.accumulator ^= byte;
     registers.set_z_flag(registers.accumulator == 0);
@@ -23,7 +26,8 @@ pub fn eor(
         cpu_instruction,
         resolution,
         format!(
-            "[A=0x{:02x}][S={}]",
+            "(0x{:02x})[A=0x{:02x}][S={}]",
+            byte,
             registers.accumulator,
             registers.format_status()
         ),
@@ -38,8 +42,8 @@ mod tests {
     #[test]
     fn test_eor() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "EOR", AddressingMode::Immediate([0x0a]), eor);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x49, "EOR", AddressingMode::Immediate([0x0a]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x49, 0x0a]);
         registers.accumulator = 0x02;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -49,35 +53,104 @@ mod tests {
         assert_eq!(0x1002, registers.command_pointer);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (49 0a)       EOR  #$0a     (#0x1001)  (0x0a)[A=0x08][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_eor_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x4D, "EOR", AddressingMode::Absolute([0x00, 0x20]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4D, 0x00, 0x20]);
+        registers.accumulator = 0x02;
+        memory.write(0x2000, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x08, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (4d 00 20)    EOR  $2000    (#0x2000)  (0x0a)[A=0x08][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_eor_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x5D, "EOR", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x5D, 0xFF, 0x10]);
+        registers.register_x = 0x01;
+        registers.accumulator = 0x02;
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x08, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Absolute,X with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (5d ff 10)    EOR  $10FF,X  (#0x1100)  (0x0a)[A=0x08][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_eor_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x45, "EOR", AddressingMode::ZeroPage([0x20]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x45, 0x20]);
+        registers.accumulator = 0x02;
+        memory.write(0x20, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x08, registers.accumulator);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (45 20)       EOR  $20      (#0x0020)  (0x0a)[A=0x08][S=nv-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_eor_with_z() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "EOR", AddressingMode::Immediate([0x0a]), eor);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x49, "EOR", AddressingMode::Immediate([0x0a]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x49, 0x0a]);
         registers.accumulator = 0x0a;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert_eq!(0x1002, registers.command_pointer);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (49 0a)       EOR  #$0a     (#0x1001)  (0x0a)[A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_eor_with_n() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "EOR", AddressingMode::Immediate([0x0a]), eor);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x49, "EOR", AddressingMode::Immediate([0x0a]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x49, 0x0a]);
         registers.accumulator = 0xfa;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0xf0, registers.accumulator);
         assert_eq!(0x1002, registers.command_pointer);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (49 0a)       EOR  #$0a     (#0x1001)  (0x0a)[A=0xf0][S=Nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_eor_indirect_y() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x51, "EOR", AddressingMode::ZeroPageIndirectYIndexed([0x20]), eor);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x51, 0x20]);
+        registers.register_y = 0x01;
+        registers.accumulator = 0x02;
+        memory.write(0x20, &[0xFF, 0x10]).unwrap();
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x08, registers.accumulator);
+        assert_eq!(6, log_line.cycles); // Indirect,Y with page cross: 5 + 1 cycles
+        assert_eq!("#0x1000: (51 20)       EOR  ($20),Y  (#0x1100)  (0x0a)[A=0x08][S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/inc.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/inc.rs
@@ -44,26 +44,10 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_inc() {
+    fn test_inc_accumulator() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INC", AddressingMode::ZeroPage([0x0a]), inc);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        memory.write(0x0a, &[0x28]).unwrap();
-        let log_line = cpu_instruction
-            .execute(&mut memory, &mut registers)
-            .unwrap();
-        assert_eq!("INC".to_owned(), log_line.mnemonic);
-        assert_eq!(0x29, memory.read(0x0a, 1).unwrap()[0]);
-        assert!(!registers.z_flag_is_set());
-        assert!(!registers.n_flag_is_set());
-        assert_eq!(0x1002, registers.command_pointer);
-    }
-
-    #[test]
-    fn test_inc_acc() {
-        let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INC", AddressingMode::Accumulator, inc);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x1A, "INC", AddressingMode::Accumulator, inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1A]);
         registers.accumulator = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -73,33 +57,120 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator mode: 2 cycles
+        assert_eq!("#0x1000: (1a)          INC  A                   [A=0x29][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_inc_with_z_flag() {
+    fn test_inc_zero_page() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INC", AddressingMode::Accumulator, inc);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.accumulator = 0xff;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xE6, "INC", AddressingMode::ZeroPage([0x0a]), inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xE6, 0x0a]);
+        memory.write(0x0a, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("INC".to_owned(), log_line.mnemonic);
+        assert_eq!(0x29, memory.read(0x0a, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // Zero page: 5 cycles
+        assert_eq!("#0x1000: (e6 0a)       INC  $0a      (#0x000A)  (0x29)[S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_inc_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xF6, "INC", AddressingMode::ZeroPageXIndexed([0x20]), inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xF6, 0x20]);
+        registers.register_x = 0x05; // Target address: 0x25
+        memory.write(0x25, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x29, memory.read(0x25, 1).unwrap()[0]);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Zero page X: 6 cycles
+        assert_eq!("#0x1000: (f6 20)       INC  $20,X    (#0x0025)  (0x29)[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_inc_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xEE, "INC", AddressingMode::Absolute([0x00, 0x20]), inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xEE, 0x00, 0x20]);
+        memory.write(0x2000, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x29, memory.read(0x2000, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (ee 00 20)    INC  $2000    (#0x2000)  (0x29)[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_inc_absolute_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xFE, "INC", AddressingMode::AbsoluteXIndexed([0x00, 0x20]), inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xFE, 0x00, 0x20]);
+        registers.register_x = 0x05; // Target address: 0x2005
+        memory.write(0x2005, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x29, memory.read(0x2005, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(7, log_line.cycles); // Absolute X: 7 cycles
+        assert_eq!("#0x1000: (fe 00 20)    INC  $2000,X  (#0x2005)  (0x29)[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_inc_absolute_x_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xFE, "INC", AddressingMode::AbsoluteXIndexed([0xFB, 0x20]), inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xFE, 0xFB, 0x20]);
+        registers.register_x = 0x05; // Target address: 0x2100 (page cross)
+        memory.write(0x2100, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x29, memory.read(0x2100, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(7, log_line.cycles); // Absolute X: 7 cycles (no extra cycle for page cross on write)
+        assert_eq!("#0x1000: (fe fb 20)    INC  $20FB,X  (#0x2100)  (0x29)[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_inc_with_zero_result() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x1A, "INC", AddressingMode::Accumulator, inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1A]);
+        registers.accumulator = 0xFF;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (1a)          INC  A                   [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_inc_with_n_flag() {
+    fn test_inc_with_negative_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INC", AddressingMode::Accumulator, inc);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.accumulator = 0xf7;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0x1A, "INC", AddressingMode::Accumulator, inc);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1A]);
+        registers.accumulator = 0x7F;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xf8, registers.accumulator);
+        assert_eq!(0x80, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (1a)          INC  A                   [A=0x80][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/inx.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/inx.rs
@@ -39,8 +39,8 @@ mod tests {
     #[test]
     fn test_inx() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INX", AddressingMode::Implied, inx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xE8, "INX", AddressingMode::Implied, inx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xE8]);
         registers.register_x = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -50,35 +50,41 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // INX takes 2 cycles
+        assert_eq!("#0x1000: (e8)          INX                      [X=0x29][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_inx_with_z_flag() {
+    fn test_inx_with_zero_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INX", AddressingMode::Implied, inx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.register_x = 0xff;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xE8, "INX", AddressingMode::Implied, inx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xE8]);
+        registers.register_x = 0xFF;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_x);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (e8)          INX                      [X=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_inx_with_n_flag() {
+    fn test_inx_with_negative_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INX", AddressingMode::Implied, inx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.register_x = 0xf7;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xE8, "INX", AddressingMode::Implied, inx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xE8]);
+        registers.register_x = 0x7F;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xf8, registers.register_x);
+        assert_eq!(0x80, registers.register_x);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (e8)          INX                      [X=0x80][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/iny.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/iny.rs
@@ -39,8 +39,8 @@ mod tests {
     #[test]
     fn test_iny() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INY", AddressingMode::Implied, iny);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xC8, "INY", AddressingMode::Implied, iny);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xC8]);
         registers.register_y = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -50,35 +50,41 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // INY takes 2 cycles
+        assert_eq!("#0x1000: (c8)          INY                      [Y=0x29][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_iny_with_z_flag() {
+    fn test_iny_with_zero_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INY", AddressingMode::Implied, iny);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.register_y = 0xff;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xC8, "INY", AddressingMode::Implied, iny);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xC8]);
+        registers.register_y = 0xFF;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_y);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (c8)          INY                      [Y=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_iny_with_n_flag() {
+    fn test_iny_with_negative_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "INY", AddressingMode::Implied, iny);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
-        registers.register_y = 0xf7;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xC8, "INY", AddressingMode::Implied, iny);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xC8]);
+        registers.register_y = 0x7F;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xf8, registers.register_y);
+        assert_eq!(0x80, registers.register_y);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (c8)          INY                      [Y=0x80][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/jmp.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/jmp.rs
@@ -18,7 +18,7 @@ pub fn jmp(
     Ok(LogLine::new(
         cpu_instruction,
         resolution,
-        format!("[CP=0x{:04x}]", registers.command_pointer),
+        format!("[CP=0x{:04x}][S={}]", registers.command_pointer, registers.format_status()),
     ))
 }
 
@@ -28,19 +28,112 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_jmp() {
+    fn test_jmp_absolute() {
         let cpu_instruction = CPUInstruction::new(
             0x1000,
-            0xca,
+            0x4C,
             "JMP",
             AddressingMode::Absolute([0x0a, 0x02]),
             jmp,
         );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4C, 0x0a, 0x02]);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("JMP".to_owned(), log_line.mnemonic);
         assert_eq!(0x020a, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // Absolute: 3 cycles
+        assert_eq!("#0x1000: (4c 0a 02)    JMP  $020A    (#0x020A)  [CP=0x020a][S=nv-Bdizc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_jmp_indirect() {
+        let cpu_instruction = CPUInstruction::new(
+            0x1000,
+            0x6C,
+            "JMP",
+            AddressingMode::Indirect([0x20, 0x02]),
+            jmp,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6C, 0x20, 0x02]);
+        memory.write(0x0220, &[0x34, 0x12]).unwrap(); // Target address at $0220 points to $1234
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("JMP".to_owned(), log_line.mnemonic);
+        assert_eq!(0x1234, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Indirect: 6 cycles on 65C02 (5 on 6502)
+        assert_eq!("#0x1000: (6c 20 02)    JMP  ($0220)  (#0x1234)  [CP=0x1234][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_jmp_indirect_page_boundary() {
+        // Test the 65C02 fix for the 6502 JMP indirect bug at page boundaries
+        let cpu_instruction = CPUInstruction::new(
+            0x1000,
+            0x6C,
+            "JMP",
+            AddressingMode::Indirect([0xFF, 0x12]), // Address $12FF at page boundary
+            jmp,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6C, 0xFF, 0x12]);
+        memory.write(0x12FF, &[0x34]).unwrap(); // Low byte at $12FF
+        memory.write(0x1300, &[0x12]).unwrap(); // High byte at $1300 (65C02 fix, 6502 would read from $1200)
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1234, registers.command_pointer); // Should read high byte from correct page ($1300)
+        assert_eq!(6, log_line.cycles); // 6 cycles on 65C02 due to page boundary fix
+        assert_eq!("#0x1000: (6c ff 12)    JMP  ($12FF)  (#0x1234)  [CP=0x1234][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_jmp_indirect_page_boundary_bug_fix() {
+        let cpu_instruction = CPUInstruction::new(
+            0x1000,
+            0x6C,
+            "JMP",
+            AddressingMode::Indirect([0xFF, 0x12]), // $12FF - page boundary address
+            jmp,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6C, 0xFF, 0x12]);
+        
+        // Set up both possible high bytes:
+        // - $1200 (where 6502 would incorrectly read from)
+        // - $1300 (where 65C02 correctly reads from)
+        memory.write(0x12FF, &[0x34]).unwrap(); // Low byte at $12FF
+        memory.write(0x1200, &[0xBB]).unwrap(); // Wrong high byte (6502 bug would read this)
+        memory.write(0x1300, &[0x12]).unwrap(); // Correct high byte (65C02 reads this)
+
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+
+        // Should jump to $1234 (using high byte from $1300)
+        // NOT $BB34 (which would happen if reading high byte from $1200)
+        assert_eq!(0x1234, registers.command_pointer, 
+            "Should read high byte from $1300, not $1200 like the 6502 bug");
+        assert_eq!(6, log_line.cycles, "Should take 6 cycles due to page boundary fix");
+        assert_eq!("#0x1000: (6c ff 12)    JMP  ($12FF)  (#0x1234)  [CP=0x1234][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_jmp_indirect_indexed() {
+        let cpu_instruction = CPUInstruction::new(
+            0x1000,
+            0x7C,
+            "JMP",
+            AddressingMode::AbsoluteXIndexedIndirect([0x20, 0x02]),
+            jmp,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7C, 0x20, 0x02]);
+        registers.register_x = 0x02; // Target address will be at $0222
+        memory.write(0x0222, &[0x34, 0x12]).unwrap(); // Target address stored at $0222
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x1234, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Indirect Indexed: 6 cycles
+        assert_eq!("#0x1000: (7c 20 02)    JMP  ($0220,X)(#0x1234)  [CP=0x1234][S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/lda.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/lda.rs
@@ -9,6 +9,10 @@ pub fn lda(
         cpu_instruction
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
+            
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+            
     let target_address = resolution
         .target_address
         .expect("LDA instruction must have operands, crashing the application");
@@ -37,8 +41,8 @@ mod tests {
     #[test]
     fn test_lda() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDA", AddressingMode::ZeroPage([0x0a]), lda);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x0a]);
+            CPUInstruction::new(0x1000, 0xA5, "LDA", AddressingMode::ZeroPage([0x0a]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA5, 0x0a]);
         registers.accumulator = 0x10;
         memory.write(0x000a, &[0x5a]).unwrap();
         let log_line = cpu_instruction
@@ -49,34 +53,204 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (a5 0a)       LDA  $0a      (#0x000A)  [A=0x5a][S=nv-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_lda_negative() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDA", AddressingMode::ZeroPage([0x0a]), lda);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x0a]);
+            CPUInstruction::new(0x1000, 0xA5, "LDA", AddressingMode::ZeroPage([0x0a]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA5, 0x0a]);
         registers.accumulator = 0x10;
         memory.write(0x000a, &[0x80]).unwrap();
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x80, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (a5 0a)       LDA  $0a      (#0x000A)  [A=0x80][S=Nv-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_lda_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDA", AddressingMode::ZeroPage([0x0a]), lda);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x0a]);
+            CPUInstruction::new(0x1000, 0xA5, "LDA", AddressingMode::ZeroPage([0x0a]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA5, 0x0a]);
         registers.accumulator = 0x10;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (a5 0a)       LDA  $0a      (#0x000A)  [A=0x00][S=nv-BdiZc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xBD, "LDA", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBD, 0xFF, 0x10]);
+        registers.register_x = 0x01; // This will cause page crossing: $10FF + $01 = $1100
+        memory.write(0x1100, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Absolute,X with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (bd ff 10)    LDA  $10FF,X  (#0x1100)  [A=0x42][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_absolute_x_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xBD, "LDA", AddressingMode::AbsoluteXIndexed([0x50, 0x10]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBD, 0x50, 0x10]);
+        registers.register_x = 0x01; // No page crossing: $1050 + $01 = $1051
+        memory.write(0x1051, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Absolute,X without page cross: 4 cycles
+        assert_eq!("#0x1000: (bd 50 10)    LDA  $1050,X  (#0x1051)  [A=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_immediate() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xA9, "LDA", AddressingMode::Immediate([0x42]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA9, 0x42]);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (a9 42)       LDA  #$42     (#0x1001)  [A=0x42][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xA5, "LDA", AddressingMode::ZeroPage([0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA5, 0x44]);
+        memory.write(0x44, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (a5 44)       LDA  $44      (#0x0044)  [A=0x42][S=nv-Bdizc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB5, "LDA", AddressingMode::ZeroPageXIndexed([0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB5, 0x44]);
+        registers.register_x = 0x02; // Target address will be $46
+        memory.write(0x46, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Zero Page,X: 4 cycles
+        assert_eq!("#0x1000: (b5 44)       LDA  $44,X    (#0x0046)  [A=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xAD, "LDA", AddressingMode::Absolute([0x00, 0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xAD, 0x00, 0x44]);
+        memory.write(0x4400, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (ad 00 44)    LDA  $4400    (#0x4400)  [A=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_absolute_y_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB9, "LDA", AddressingMode::AbsoluteYIndexed([0xFF, 0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB9, 0xFF, 0x44]);
+        registers.register_y = 0x01; // This will cause page crossing: $44FF + $01 = $4500
+        memory.write(0x4500, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Absolute,Y with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (b9 ff 44)    LDA  $44FF,Y  (#0x4500)  [A=0x42][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_absolute_y_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB9, "LDA", AddressingMode::AbsoluteYIndexed([0x50, 0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB9, 0x50, 0x44]);
+        registers.register_y = 0x01; // No page crossing: $4450 + $01 = $4451
+        memory.write(0x4451, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Absolute,Y without page cross: 4 cycles
+        assert_eq!("#0x1000: (b9 50 44)    LDA  $4450,Y  (#0x4451)  [A=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_indirect_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xA1, "LDA", AddressingMode::ZeroPageXIndexedIndirect([0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA1, 0x44]);
+        registers.register_x = 0x02; // Address to read from will be $46
+        memory.write(0x46, &[0x00, 0x44]).unwrap(); // Points to $4400
+        memory.write(0x4400, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(6, log_line.cycles); // Indirect,X: 6 cycles
+        assert_eq!("#0x1000: (a1 44)       LDA  ($44,X)  (#0x4400)  [A=0x42][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_indirect_y_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB1, "LDA", AddressingMode::ZeroPageIndirectYIndexed([0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB1, 0x44]);
+        memory.write(0x44, &[0xFF, 0x44]).unwrap(); // Points to $44FF
+        registers.register_y = 0x01; // This will cause page crossing: $44FF + $01 = $4500
+        memory.write(0x4500, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(6, log_line.cycles); // Indirect,Y with page cross: 5 + 1 cycles
+        assert_eq!("#0x1000: (b1 44)       LDA  ($44),Y  (#0x4500)  [A=0x42][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lda_indirect_y_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB1, "LDA", AddressingMode::ZeroPageIndirectYIndexed([0x44]), lda);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB1, 0x44]);
+        memory.write(0x44, &[0x50, 0x44]).unwrap(); // Points to $4450
+        registers.register_y = 0x01; // No page crossing: $4450 + $01 = $4451
+        memory.write(0x4451, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Indirect,Y without page cross: 5 cycles
+        assert_eq!("#0x1000: (b1 44)       LDA  ($44),Y  (#0x4451)  [A=0x42][S=nv-Bdizc][5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/ldx.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/ldx.rs
@@ -13,6 +13,9 @@ pub fn ldx(
         .target_address
         .expect("LDX instruction must have operands, crashing the application");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     registers.register_x = memory.read(target_address, 1)?[0];
     registers.set_n_flag(registers.register_x & 0b10000000 != 0);
     registers.set_z_flag(registers.register_x == 0);
@@ -35,10 +38,10 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_ldx() {
+    fn test_ldx_immediate() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xa0, "LDX", AddressingMode::Immediate([0x0a]), ldx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa0, 0x0a]);
+            CPUInstruction::new(0x1000, 0xA2, "LDX", AddressingMode::Immediate([0x0a]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA2, 0x0a]);
         registers.register_x = 0x10;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -48,33 +51,110 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (a2 0a)       LDX  #$0a     (#0x1001)  [X=0x0a][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldx_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xA6, "LDX", AddressingMode::ZeroPage([0x44]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA6, 0x44]);
+        memory.write(0x44, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_x);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (a6 44)       LDX  $44      (#0x0044)  [X=0x42][S=nv-Bdizc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldx_zero_page_y() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB6, "LDX", AddressingMode::ZeroPageYIndexed([0x20]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB6, 0x20]);
+        registers.register_y = 0x05; // Target address will be $25
+        memory.write(0x25, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_x);
+        assert_eq!(4, log_line.cycles); // Zero Page,Y: 4 cycles
+        assert_eq!("#0x1000: (b6 20)       LDX  $20,Y    (#0x0025)  [X=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldx_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xAE, "LDX", AddressingMode::Absolute([0x00, 0x44]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xAE, 0x00, 0x44]);
+        memory.write(0x4400, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_x);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (ae 00 44)    LDX  $4400    (#0x4400)  [X=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldx_absolute_y_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xBE, "LDX", AddressingMode::AbsoluteYIndexed([0xFF, 0x44]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBE, 0xFF, 0x44]);
+        registers.register_y = 0x01; // This will cause page crossing: $44FF + $01 = $4500
+        memory.write(0x4500, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_x);
+        assert_eq!(5, log_line.cycles); // Absolute,Y with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (be ff 44)    LDX  $44FF,Y  (#0x4500)  [X=0x42][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldx_absolute_y_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xBE, "LDX", AddressingMode::AbsoluteYIndexed([0x50, 0x44]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBE, 0x50, 0x44]);
+        registers.register_y = 0x01; // No page crossing: $4450 + $01 = $4451
+        memory.write(0x4451, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_x);
+        assert_eq!(4, log_line.cycles); // Absolute,Y without page cross: 4 cycles
+        assert_eq!("#0x1000: (be 50 44)    LDX  $4450,Y  (#0x4451)  [X=0x42][S=nv-Bdizc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_ldx_negative() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDX", AddressingMode::Immediate([0x8a]), ldx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x8a]);
-        registers.register_x = 0x10;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xA2, "LDX", AddressingMode::Immediate([0x8a]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA2, 0x8a]);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x8a, registers.register_x);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (a2 8a)       LDX  #$8a     (#0x1001)  [X=0x8a][S=Nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ldx_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDX", AddressingMode::Immediate([0x00]), ldx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x00]);
-        registers.register_x = 0x10;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xA2, "LDX", AddressingMode::Immediate([0x00]), ldx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA2, 0x00]);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_x);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (a2 00)       LDX  #$00     (#0x1001)  [X=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/ldy.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/ldy.rs
@@ -13,6 +13,9 @@ pub fn ldy(
         .target_address
         .expect("LDY instruction must have operands, crashing the application");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     registers.register_y = memory.read(target_address, 1)?[0];
     registers.set_n_flag(registers.register_y & 0b10000000 != 0);
     registers.set_z_flag(registers.register_y == 0);
@@ -35,10 +38,10 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_ldy() {
+    fn test_ldy_immediate() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xa0, "LDY", AddressingMode::Immediate([0x0a]), ldy);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa0, 0x0a]);
+            CPUInstruction::new(0x1000, 0xA0, "LDY", AddressingMode::Immediate([0x0a]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA0, 0x0a]);
         registers.register_y = 0x10;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -48,33 +51,110 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (a0 0a)       LDY  #$0a     (#0x1001)  [Y=0x0a][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldy_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xA4, "LDY", AddressingMode::ZeroPage([0x44]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA4, 0x44]);
+        memory.write(0x44, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_y);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (a4 44)       LDY  $44      (#0x0044)  [Y=0x42][S=nv-Bdizc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldy_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xB4, "LDY", AddressingMode::ZeroPageXIndexed([0x20]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xB4, 0x20]);
+        registers.register_x = 0x05; // Target address will be $25
+        memory.write(0x25, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_y);
+        assert_eq!(4, log_line.cycles); // Zero Page,X: 4 cycles
+        assert_eq!("#0x1000: (b4 20)       LDY  $20,X    (#0x0025)  [Y=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldy_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xAC, "LDY", AddressingMode::Absolute([0x00, 0x44]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xAC, 0x00, 0x44]);
+        memory.write(0x4400, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_y);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (ac 00 44)    LDY  $4400    (#0x4400)  [Y=0x42][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldy_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xBC, "LDY", AddressingMode::AbsoluteXIndexed([0xFF, 0x44]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBC, 0xFF, 0x44]);
+        registers.register_x = 0x01; // This will cause page crossing: $44FF + $01 = $4500
+        memory.write(0x4500, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_y);
+        assert_eq!(5, log_line.cycles); // Absolute,X with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (bc ff 44)    LDY  $44FF,X  (#0x4500)  [Y=0x42][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ldy_absolute_x_no_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xBC, "LDY", AddressingMode::AbsoluteXIndexed([0x50, 0x44]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBC, 0x50, 0x44]);
+        registers.register_x = 0x01; // No page crossing: $4450 + $01 = $4451
+        memory.write(0x4451, &[0x42]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, registers.register_y);
+        assert_eq!(4, log_line.cycles); // Absolute,X without page cross: 4 cycles
+        assert_eq!("#0x1000: (bc 50 44)    LDY  $4450,X  (#0x4451)  [Y=0x42][S=nv-Bdizc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_ldy_negative() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDY", AddressingMode::Immediate([0x8a]), ldy);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x8a]);
-        registers.register_y = 0x10;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xA0, "LDY", AddressingMode::Immediate([0x8a]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA0, 0x8a]);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x8a, registers.register_y);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (a0 8a)       LDY  #$8a     (#0x1001)  [Y=0x8a][S=Nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ldy_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LDY", AddressingMode::Immediate([0x00]), ldy);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x00]);
-        registers.register_y = 0x10;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xA0, "LDY", AddressingMode::Immediate([0x00]), ldy);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA0, 0x00]);
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_y);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (a0 00)       LDY  #$00     (#0x1001)  [Y=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/lsr.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/lsr.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+/// # LSR - Logical Shift Right
+///
+/// On the 65C02 (unlike the 6502):
+/// - LSR absolute,X takes 6 cycles when no page boundary is crossed
+/// - LSR absolute,X takes 7 cycles when a page boundary is crossed
+/// - On the 6502, LSR absolute,X always takes 7 cycles regardless of page crossing
+///
+/// This implementation follows the 65C02 behavior.
+/// See http://www.6502.org/tutorials/65c02opcodes.html
 pub fn lsr(
     memory: &mut Memory,
     registers: &mut Registers,
@@ -9,6 +18,9 @@ pub fn lsr(
         cpu_instruction
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
+
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
 
     let byte = match resolution.target_address {
         Some(addr) => memory.read(addr, 1)?[0],
@@ -43,8 +55,8 @@ mod tests {
     #[test]
     fn test_lsr() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LSR", AddressingMode::ZeroPage([0x0a]), lsr);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x46, "LSR", AddressingMode::ZeroPage([0x0a]), lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x46, 0x0a]);
         memory.write(0x0a, &[0x28]).unwrap();
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -55,15 +67,47 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // Zero Page: 5 cycles
+        assert_eq!("#0x1000: (46 0a)       LSR  $0a      (#0x000A)  0x14[S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lsr_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x5E, "LSR", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x5E, 0xFF, 0x10]);
+        registers.register_x = 0x01; // This will cause page crossing: $10FF + $01 = $1100
+        memory.write(0x1100, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x1100, 1).unwrap()[0]);
+        assert_eq!(7, log_line.cycles); // Absolute,X: 6 cycles + 1 for page crossing
+        assert_eq!("#0x1000: (5e ff 10)    LSR  $10FF,X  (#0x1100)  0x14[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lsr_absolute_x_without_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x5E, "LSR", AddressingMode::AbsoluteXIndexed([0x80, 0x10]), lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x5E, 0x80, 0x10]);
+        registers.register_x = 0x01; // No page crossing: $1080 + $01 = $1081
+        memory.write(0x1081, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x1081, 1).unwrap()[0]);
+        assert_eq!(6, log_line.cycles); // Absolute,X: 6 cycles (no page crossing)
+        assert_eq!("#0x1000: (5e 80 10)    LSR  $1080,X  (#0x1081)  0x14[S=nv-Bdizc][6]", log_line.to_string());
     }
 
     #[test]
     fn test_lsr_acc() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LSR", AddressingMode::Accumulator, lsr);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x4A, "LSR", AddressingMode::Accumulator, lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4A]);
         registers.accumulator = 0x28;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x14, registers.accumulator);
@@ -71,51 +115,99 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (4a)          LSR  A                   [A=0x14][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_lsr_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LSR", AddressingMode::Accumulator, lsr);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x4A, "LSR", AddressingMode::Accumulator, lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4A]);
         registers.accumulator = 0x00;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (4a)          LSR  A                   [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_lsr_with_c_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LSR", AddressingMode::Accumulator, lsr);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x4A, "LSR", AddressingMode::Accumulator, lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4A]);
         registers.accumulator = 0x81;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x40, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(registers.c_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (4a)          LSR  A                   [A=0x40][S=nv-BdizC][2]", log_line.to_string());
     }
 
     #[test]
     fn test_lsr_with_n_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "LSR", AddressingMode::Accumulator, lsr);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x4A, "LSR", AddressingMode::Accumulator, lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4A]);
         registers.accumulator = 0xfe;
         registers.set_n_flag(true);
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x7f, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (4a)          LSR  A                   [A=0x7f][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lsr_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x4E, "LSR", AddressingMode::Absolute([0x00, 0x20]), lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4E, 0x00, 0x20]);
+        memory.write(0x2000, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (4e 00 20)    LSR  $2000    (#0x2000)  0x14[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_lsr_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x56, "LSR", AddressingMode::ZeroPageXIndexed([0x20]), lsr);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x56, 0x20]);
+        registers.register_x = 0x05; // Target address will be $25
+        memory.write(0x25, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x25, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Zero Page,X: 6 cycles
+        assert_eq!("#0x1000: (56 20)       LSR  $20,X    (#0x0025)  0x14[S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/nop.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/nop.rs
@@ -11,5 +11,43 @@ pub fn nop(
             .solve(registers.command_pointer, memory, registers)?;
     registers.command_pointer += 1 + resolution.operands.len();
 
-    Ok(LogLine::new(cpu_instruction, resolution, String::new()))
+    Ok(LogLine::new(
+        cpu_instruction,
+        resolution,
+        format!("[S={}]", registers.format_status())
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
+
+    #[test]
+    fn test_nop_implied() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0xea, "NOP", AddressingMode::Implied, nop);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xea]);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("NOP".to_owned(), log_line.mnemonic);
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Implied: 2 cycles
+        assert_eq!("#0x1000: (ea)          NOP                      [S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_nop_immediate() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x02, "NOP", AddressingMode::Immediate([0x42]), nop);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x02, 0x42]);
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("NOP".to_owned(), log_line.mnemonic);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Immediate: 2 cycles
+        assert_eq!("#0x1000: (02 42)       NOP  #$42     (#0x1001)  [S=nv-Bdizc][2]", log_line.to_string());
+    }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/ora.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/ora.rs
@@ -13,6 +13,9 @@ pub fn ora(
         .target_address
         .expect("ORA must have operands, crashing the application");
 
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
+
     let byte = memory.read(target_address, 1)?[0];
     registers.accumulator |= byte;
     registers.set_z_flag(registers.accumulator == 0);
@@ -23,7 +26,8 @@ pub fn ora(
         cpu_instruction,
         resolution,
         format!(
-            "[A=0x{:02x}][S={}]",
+            "(0x{:02x})[A=0x{:02x}][S={}]",
+            byte,
             registers.accumulator,
             registers.format_status()
         ),
@@ -38,8 +42,8 @@ mod tests {
     #[test]
     fn test_ora() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ORA", AddressingMode::Immediate([0x0a]), ora);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x00, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x09, "ORA", AddressingMode::Immediate([0x0a]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x09, 0x0a]);
         registers.accumulator = 0x22;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -49,33 +53,102 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (09 0a)       ORA  #$0a     (#0x1001)  (0x0a)[A=0x2a][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ora_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x0D, "ORA", AddressingMode::Absolute([0x00, 0x20]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0D, 0x00, 0x20]);
+        registers.accumulator = 0x22;
+        memory.write(0x2000, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x2A, registers.accumulator);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (0d 00 20)    ORA  $2000    (#0x2000)  (0x0a)[A=0x2a][S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ora_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x1D, "ORA", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1D, 0xFF, 0x10]);
+        registers.register_x = 0x01;
+        registers.accumulator = 0x22;
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x2A, registers.accumulator);
+        assert_eq!(5, log_line.cycles); // Absolute,X with page cross: 4 + 1 cycles
+        assert_eq!("#0x1000: (1d ff 10)    ORA  $10FF,X  (#0x1100)  (0x0a)[A=0x2a][S=nv-Bdizc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ora_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x05, "ORA", AddressingMode::ZeroPage([0x20]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x05, 0x20]);
+        registers.accumulator = 0x22;
+        memory.write(0x20, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x2A, registers.accumulator);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (05 20)       ORA  $20      (#0x0020)  (0x0a)[A=0x2a][S=nv-Bdizc][3]", log_line.to_string());
     }
 
     #[test]
     fn test_ora_set_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ORA", AddressingMode::Immediate([0x00]), ora);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x00, 0x02]);
+            CPUInstruction::new(0x1000, 0x09, "ORA", AddressingMode::Immediate([0x00]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x09, 0x00]);
         registers.accumulator = 0x00;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (09 00)       ORA  #$00     (#0x1001)  (0x00)[A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ora_set_negative() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ORA", AddressingMode::Immediate([0x00]), ora);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x00]);
-        registers.accumulator = 0xd5;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0x09, "ORA", AddressingMode::Immediate([0x80]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x09, 0x80]);
+        registers.accumulator = 0x00;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xd5, registers.accumulator);
+        assert_eq!(0x80, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Immediate mode: 2 cycles
+        assert_eq!("#0x1000: (09 80)       ORA  #$80     (#0x1001)  (0x80)[A=0x80][S=Nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ora_indirect_y() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x11, "ORA", AddressingMode::ZeroPageIndirectYIndexed([0x20]), ora);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x11, 0x20]);
+        registers.register_y = 0x01;
+        registers.accumulator = 0x22;
+        memory.write(0x20, &[0xFF, 0x10]).unwrap();
+        memory.write(0x1100, &[0x0A]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x2A, registers.accumulator);
+        assert_eq!(6, log_line.cycles); // Indirect,Y with page cross: 5 + 1 cycles
+        assert_eq!("#0x1000: (11 20)       ORA  ($20),Y  (#0x1100)  (0x0a)[A=0x2a][S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/pha.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/pha.rs
@@ -16,7 +16,7 @@ pub fn pha(
     Ok(LogLine::new(
         cpu_instruction,
         resolution,
-        format!("[SP={:02x}]", registers.stack_pointer),
+        format!("[SP=0x{:02x}]", registers.stack_pointer),
     ))
 }
 
@@ -29,7 +29,7 @@ mod tests {
     #[test]
     fn test_pha() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PHA", AddressingMode::Implied, pha);
+            CPUInstruction::new(0x1000, 0x48, "PHA", AddressingMode::Implied, pha);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
         registers.accumulator = 0x10;
         let log_line = cpu_instruction
@@ -39,5 +39,7 @@ mod tests {
         assert_eq!(0x10, memory.read(STACK_BASE_ADDR + 0x00ff, 1).unwrap()[0]);
         assert_eq!(0xfe, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // PHA takes 3 cycles
+        assert_eq!("#0x1000: (48)          PHA                      [SP=0xfe][3]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/php.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/php.rs
@@ -29,13 +29,12 @@ mod tests {
     #[test]
     fn test_php() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PHP", AddressingMode::Implied, php);
+            CPUInstruction::new(0x1000, 0x08, "PHP", AddressingMode::Implied, php);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
         registers.set_d_flag(true);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!("[SP=0xfe]", format!("{}", log_line.outcome));
         assert_eq!("PHP".to_owned(), log_line.mnemonic);
         assert_eq!(
             0b00111000,
@@ -43,5 +42,7 @@ mod tests {
         );
         assert_eq!(0xfe, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // PHP takes 3 cycles
+        assert_eq!("#0x1000: (08)          PHP                      [SP=0xfe][3]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/phx.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/phx.rs
@@ -27,18 +27,19 @@ mod tests {
     use crate::STACK_BASE_ADDR;
 
     #[test]
-    fn test_php() {
+    fn test_phx() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PHX", AddressingMode::Implied, phx);
+            CPUInstruction::new(0x1000, 0xda, "PHX", AddressingMode::Implied, phx);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
         registers.register_x = 0xa1;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!("[SP=0xfe]", format!("{}", log_line.outcome));
         assert_eq!("PHX".to_owned(), log_line.mnemonic);
         assert_eq!(0xa1, memory.read(STACK_BASE_ADDR + 0x00ff, 1).unwrap()[0]);
         assert_eq!(0xfe, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // PHX takes 3 cycles
+        assert_eq!("#0x1000: (da)          PHX                      [SP=0xfe][3]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/phy.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/phy.rs
@@ -29,16 +29,17 @@ mod tests {
     #[test]
     fn test_phy() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PHY", AddressingMode::Implied, phy);
+            CPUInstruction::new(0x1000, 0x5a, "PHY", AddressingMode::Implied, phy);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
         registers.register_y = 0xa1;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!("[SP=0xfe]", format!("{}", log_line.outcome));
         assert_eq!("PHY".to_owned(), log_line.mnemonic);
         assert_eq!(0xa1, memory.read(STACK_BASE_ADDR + 0x00ff, 1).unwrap()[0]);
         assert_eq!(0xfe, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // PHY takes 3 cycles
+        assert_eq!("#0x1000: (5a)          PHY                      [SP=0xfe][3]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/pla.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/pla.rs
@@ -31,14 +31,14 @@ pub fn pla(
 mod tests {
     use super::*;
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
+    use crate::STACK_BASE_ADDR;
 
     #[test]
     fn test_pla() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0x08, "PLA", AddressingMode::Implied, pla);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x08, 0x0a]);
-        memory.write(0x01ff, &[0x10]).unwrap();
-        registers.accumulator = 0x00;
+            CPUInstruction::new(0x1000, 0x68, "PLA", AddressingMode::Implied, pla);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x68, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x10]).unwrap();
         registers.stack_pointer = 0xfe;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -47,47 +47,45 @@ mod tests {
         assert_eq!(0x10, registers.accumulator);
         assert_eq!(0xff, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
-        assert!(!registers.n_flag_is_set());
-        assert!(!registers.z_flag_is_set());
-        assert_eq!(
-            format!(
-                "#0x1000: (08)          PLA                      [A=0x10][SP=0xff][S=nv-Bdizc]"
-            ),
-            format!("{}", log_line)
-        );
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (68)          PLA                      [A=0x10][SP=0xff][S=nv-Bdizc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_pla_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PLA", AddressingMode::Implied, pla);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
-        memory.write(0x01ff, &[0x00]).unwrap();
+            CPUInstruction::new(0x1000, 0x68, "PLA", AddressingMode::Implied, pla);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x68, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x00]).unwrap();
         registers.accumulator = 0x10;
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert_eq!(0xff, registers.stack_pointer);
         assert!(!registers.n_flag_is_set());
         assert!(registers.z_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (68)          PLA                      [A=0x00][SP=0xff][S=nv-BdiZc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_pla_neg() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PLA", AddressingMode::Implied, pla);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
-        memory.write(0x01ff, &[0x81]).unwrap();
+            CPUInstruction::new(0x1000, 0x68, "PLA", AddressingMode::Implied, pla);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x68, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x81]).unwrap();
         registers.accumulator = 0x10;
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x81, registers.accumulator);
         assert_eq!(0xff, registers.stack_pointer);
         assert!(registers.n_flag_is_set());
         assert!(!registers.z_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (68)          PLA                      [A=0x81][SP=0xff][S=Nv-Bdizc][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/plp.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/plp.rs
@@ -34,8 +34,8 @@ mod tests {
     #[test]
     fn test_plp() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0x08, "PLP", AddressingMode::Implied, plp);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x08, 0x0a]);
+            CPUInstruction::new(0x1000, 0x28, "PLP", AddressingMode::Implied, plp);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x28, 0x0a]);
         registers.set_z_flag(true);
         registers.set_d_flag(true);
         registers.set_c_flag(false);
@@ -58,9 +58,7 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert_eq!(0xff, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (08)          PLP                      [SP=0xff][S=nv-BDiZc]"),
-            format!("{}", log_line)
-        );
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (28)          PLP                      [SP=0xff][S=nv-BDiZc][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/plx.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/plx.rs
@@ -31,13 +31,14 @@ pub fn plx(
 mod tests {
     use super::*;
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
+    use crate::STACK_BASE_ADDR;
 
     #[test]
     fn test_plx() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0x08, "PLX", AddressingMode::Implied, plx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x08, 0x0a]);
-        memory.write(0x01ff, &[0x10]).unwrap();
+            CPUInstruction::new(0x1000, 0xfa, "PLX", AddressingMode::Implied, plx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xfa, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x10]).unwrap();
         registers.register_x = 0x00;
         registers.stack_pointer = 0xfe;
         let log_line = cpu_instruction
@@ -49,45 +50,45 @@ mod tests {
         assert_eq!(0x1001, registers.command_pointer);
         assert!(!registers.n_flag_is_set());
         assert!(!registers.z_flag_is_set());
-        assert_eq!(
-            format!(
-                "#0x1000: (08)          PLX                      [X=0x10][SP=0xff][S=nv-Bdizc]"
-            ),
-            format!("{}", log_line)
-        );
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (fa)          PLX                      [X=0x10][SP=0xff][S=nv-Bdizc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_plx_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PLX", AddressingMode::Implied, plx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
-        memory.write(0x01ff, &[0x00]).unwrap();
+            CPUInstruction::new(0x1000, 0xfa, "PLX", AddressingMode::Implied, plx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xfa, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x00]).unwrap();
         registers.register_x = 0x10;
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_x);
         assert_eq!(0xff, registers.stack_pointer);
         assert!(!registers.n_flag_is_set());
         assert!(registers.z_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (fa)          PLX                      [X=0x00][SP=0xff][S=nv-BdiZc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_plx_neg() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PLX", AddressingMode::Implied, plx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
-        memory.write(0x01ff, &[0x81]).unwrap();
+            CPUInstruction::new(0x1000, 0xfa, "PLX", AddressingMode::Implied, plx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xfa, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x81]).unwrap();
         registers.register_x = 0x10;
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x81, registers.register_x);
         assert_eq!(0xff, registers.stack_pointer);
         assert!(registers.n_flag_is_set());
         assert!(!registers.z_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (fa)          PLX                      [X=0x81][SP=0xff][S=Nv-Bdizc][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/ply.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/ply.rs
@@ -31,13 +31,14 @@ pub fn ply(
 mod tests {
     use super::*;
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
+    use crate::STACK_BASE_ADDR;
 
     #[test]
     fn test_ply() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0x08, "PLY", AddressingMode::Implied, ply);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x08, 0x0a]);
-        memory.write(0x01ff, &[0x10]).unwrap();
+            CPUInstruction::new(0x1000, 0x7a, "PLY", AddressingMode::Implied, ply);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7a, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x10]).unwrap();
         registers.register_y = 0x00;
         registers.stack_pointer = 0xfe;
         let log_line = cpu_instruction
@@ -49,45 +50,45 @@ mod tests {
         assert_eq!(0x1001, registers.command_pointer);
         assert!(!registers.n_flag_is_set());
         assert!(!registers.z_flag_is_set());
-        assert_eq!(
-            format!(
-                "#0x1000: (08)          PLY                      [Y=0x10][SP=0xff][S=nv-Bdizc]"
-            ),
-            format!("{}", log_line)
-        );
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (7a)          PLY                      [Y=0x10][SP=0xff][S=nv-Bdizc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_ply_zero() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PLY", AddressingMode::Implied, ply);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
-        memory.write(0x01ff, &[0x00]).unwrap();
+            CPUInstruction::new(0x1000, 0x7a, "PLY", AddressingMode::Implied, ply);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7a, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x00]).unwrap();
         registers.register_y = 0x10;
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_y);
         assert_eq!(0xff, registers.stack_pointer);
         assert!(!registers.n_flag_is_set());
         assert!(registers.z_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (7a)          PLY                      [Y=0x00][SP=0xff][S=nv-BdiZc][4]", log_line.to_string());
     }
 
     #[test]
     fn test_ply_neg() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "PLY", AddressingMode::Implied, ply);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x48, 0x0a]);
-        memory.write(0x01ff, &[0x81]).unwrap();
+            CPUInstruction::new(0x1000, 0x7a, "PLY", AddressingMode::Implied, ply);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7a, 0x0a]);
+        memory.write(STACK_BASE_ADDR + 0x00ff, &[0x81]).unwrap();
         registers.register_y = 0x10;
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x81, registers.register_y);
         assert_eq!(0xff, registers.stack_pointer);
         assert!(registers.n_flag_is_set());
         assert!(!registers.z_flag_is_set());
+        assert_eq!(4, log_line.cycles); // Implied: 4 cycles
+        assert_eq!("#0x1000: (7a)          PLY                      [Y=0x81][SP=0xff][S=Nv-Bdizc][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/rmb.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/rmb.rs
@@ -49,10 +49,8 @@ mod tests {
         assert!(!registers.c_flag_is_set());
         assert!(!registers.v_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (07 0a)       RMB0 $0a      (#0x000A)  (0xfe)"),
-            format!("{}", log_line)
-        );
+        assert_eq!(5, log_line.cycles);
+        assert_eq!("#0x1000: (07 0a)       RMB0 $0a      (#0x000A)  (0xfe)[5]", log_line.to_string());
     }
 
     #[test]
@@ -71,9 +69,7 @@ mod tests {
         assert!(!registers.c_flag_is_set());
         assert!(!registers.v_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (77 0a)       RMB7 $0a      (#0x000A)  (0x7f)"),
-            format!("{}", log_line)
-        );
+        assert_eq!(5, log_line.cycles);
+        assert_eq!("#0x1000: (77 0a)       RMB7 $0a      (#0x000A)  (0x7f)[5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/ror.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/ror.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+/// # ROR - Rotate Right
+///
+/// On the 65C02 (unlike the 6502):
+/// - ROR absolute,X takes 6 cycles when no page boundary is crossed
+/// - ROR absolute,X takes 7 cycles when a page boundary is crossed
+/// - On the 6502, ROR absolute,X always takes 7 cycles regardless of page crossing
+///
+/// This implementation follows the 65C02 behavior.
+/// See http://www.6502.org/tutorials/65c02opcodes.html
 pub fn ror(
     memory: &mut Memory,
     registers: &mut Registers,
@@ -9,6 +18,9 @@ pub fn ror(
         cpu_instruction
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
+
+    // Add extra cycle for page boundary crossing in indexed addressing modes
+    cpu_instruction.adjust_base_cycles(registers, memory);
 
     let byte = match resolution.target_address {
         Some(addr) => memory.read(addr, 1)?[0],
@@ -46,8 +58,8 @@ mod tests {
     #[test]
     fn test_ror() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ROR", AddressingMode::ZeroPage([0x0a]), ror);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x66, "ROR", AddressingMode::ZeroPage([0x0a]), ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x66, 0x0a, 0x02]);
         memory.write(0x0a, &[0x28]).unwrap();
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -58,17 +70,15 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (ca 0a)       ROR  $0a      (#0x000A)  (0x14)[S=nv-Bdizc]"),
-            format!("{}", log_line)
-        );
+        assert_eq!(5, log_line.cycles); // Zero Page: 5 cycles
+        assert_eq!("#0x1000: (66 0a)       ROR  $0a      (#0x000A)  (0x14)[S=nv-Bdizc][5]", log_line.to_string());
     }
 
     #[test]
     fn test_ror_acc() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ROR", AddressingMode::Accumulator, ror);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x6a, "ROR", AddressingMode::Accumulator, ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6a, 0x0a, 0x02]);
         registers.accumulator = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -78,71 +88,144 @@ mod tests {
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (ca)          ROR  A                   [A=0x14][S=nv-Bdizc]"),
-            format!("{}", log_line)
-        );
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (6a)          ROR  A                   [A=0x14][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ror_with_previous_c_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ROR", AddressingMode::Accumulator, ror);
+            CPUInstruction::new(0x1000, 0x6a, "ROR", AddressingMode::Accumulator, ror);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x00]);
         registers.accumulator = 0x28;
         registers.set_c_flag(true);
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x94, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (6a)          ROR  A                   [A=0x94][S=Nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ror_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ROR", AddressingMode::Accumulator, ror);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x6a, "ROR", AddressingMode::Accumulator, ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6a, 0x0a, 0x02]);
         registers.accumulator = 0x00;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(!registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (6a)          ROR  A                   [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ror_with_c_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ROR", AddressingMode::Accumulator, ror);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x6a, "ROR", AddressingMode::Accumulator, ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6a, 0x0a, 0x02]);
         registers.accumulator = 0x03;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x01, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert!(registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (6a)          ROR  A                   [A=0x01][S=nv-BdizC][2]", log_line.to_string());
     }
 
     #[test]
     fn test_ror_with_n_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "ROR", AddressingMode::Accumulator, ror);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xe8, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x6a, "ROR", AddressingMode::Accumulator, ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6a, 0x0a, 0x02]);
         registers.accumulator = 0x0a;
         registers.set_c_flag(true);
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x85, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(!registers.c_flag_is_set());
         assert!(registers.n_flag_is_set());
+        assert_eq!(2, log_line.cycles); // Accumulator: 2 cycles
+        assert_eq!("#0x1000: (6a)          ROR  A                   [A=0x85][S=Nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ror_absolute_x_with_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x7E, "ROR", AddressingMode::AbsoluteXIndexed([0xFF, 0x10]), ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7E, 0xFF, 0x10]);
+        registers.register_x = 0x01; // This will cause page crossing: $10FF + $01 = $1100
+        memory.write(0x1100, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x1100, 1).unwrap()[0]);
+        assert_eq!(7, log_line.cycles); // Absolute,X: 6 cycles + 1 for page crossing
+        assert_eq!("#0x1000: (7e ff 10)    ROR  $10FF,X  (#0x1100)  (0x14)[S=nv-Bdizc][7]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ror_absolute_x_without_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x7E, "ROR", AddressingMode::AbsoluteXIndexed([0x80, 0x10]), ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x7E, 0x80, 0x10]);
+        registers.register_x = 0x01; // No page crossing: $1080 + $01 = $1081
+        memory.write(0x1081, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x1081, 1).unwrap()[0]);
+        assert_eq!(6, log_line.cycles); // Absolute,X: 6 cycles (no page crossing)
+        assert_eq!("#0x1000: (7e 80 10)    ROR  $1080,X  (#0x1081)  (0x14)[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ror_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x6E, "ROR", AddressingMode::Absolute([0x00, 0x20]), ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x6E, 0x00, 0x20]);
+        memory.write(0x2000, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (6e 00 20)    ROR  $2000    (#0x2000)  (0x14)[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_ror_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x76, "ROR", AddressingMode::ZeroPageXIndexed([0x20]), ror);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x76, 0x20]);
+        registers.register_x = 0x05; // Target address will be $25
+        memory.write(0x25, &[0x28]).unwrap();
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x14, memory.read(0x25, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Zero Page,X: 6 cycles
+        assert_eq!("#0x1000: (76 20)       ROR  $20,X    (#0x0025)  (0x14)[S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/rti.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/rti.rs
@@ -35,21 +35,93 @@ mod tests {
     use crate::STACK_BASE_ADDR;
 
     #[test]
-    fn test_rti() {
+    fn test_rti_basic() {
         let cpu_instruction =
-            CPUInstruction::new(0x8000, 0xca, "RTI", AddressingMode::Implied, rti);
-        let (mut memory, mut registers) = get_stuff(0x8000, vec![0x00]);
-        memory
-            .write(STACK_BASE_ADDR + 0xfd, &[0b00110000, 0x01, 0x10])
-            .unwrap();
+            CPUInstruction::new(0x8000, 0x40, "RTI", AddressingMode::Implied, rti);
+        let (mut memory, mut registers) = get_stuff(0x8000, vec![0x40]);
+        
+        // Push test values onto stack (in reverse order as they'll be pulled):
+        // - Status flags: 0b00110000 (no flags set)
+        // - Return address: $1234
+        memory.write(STACK_BASE_ADDR + 0xfd, &[0b00110000, 0x34, 0x12]).unwrap();
         registers.stack_pointer = 0xfc;
+        
+        // Set some flags that should be overwritten
         registers.set_z_flag(true);
+        registers.set_n_flag(true);
+        registers.set_c_flag(true);
+        
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
+            
         assert_eq!("RTI".to_owned(), log_line.mnemonic);
-        assert_eq!(0x1001, registers.command_pointer);
-        assert_eq!(0xff, registers.stack_pointer);
+        assert_eq!(0x1234, registers.command_pointer, "Should return to exact address from stack");
+        assert_eq!(0xff, registers.stack_pointer, "Should pull 3 bytes from stack");
+        assert_eq!(6, log_line.cycles, "RTI should take 6 cycles");
+        
+        // Verify flags were restored from stack
+        assert!(!registers.n_flag_is_set());
+        assert!(!registers.v_flag_is_set());
+        assert!(!registers.d_flag_is_set());
+        assert!(!registers.i_flag_is_set());
         assert!(!registers.z_flag_is_set());
+        assert!(!registers.c_flag_is_set());
+        
+        assert_eq!("#0x8000: (40)          RTI                      [CP=0x1234][SP=0xff][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_rti_all_flags_set() {
+        let cpu_instruction =
+            CPUInstruction::new(0x8000, 0x40, "RTI", AddressingMode::Implied, rti);
+        let (mut memory, mut registers) = get_stuff(0x8000, vec![0x40]);
+        
+        // Set all flags in status byte (0xFF)
+        memory.write(STACK_BASE_ADDR + 0xfd, &[0xFF, 0x34, 0x12]).unwrap();
+        registers.stack_pointer = 0xfc;
+        
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+            
+        // Verify all flags were set
+        assert!(registers.n_flag_is_set());
+        assert!(registers.v_flag_is_set());
+        assert!(registers.d_flag_is_set());
+        assert!(registers.i_flag_is_set());
+        assert!(registers.z_flag_is_set());
+        assert!(registers.c_flag_is_set());
+        
+        assert_eq!(6, log_line.cycles, "RTI should take 6 cycles");
+        assert_eq!("#0x8000: (40)          RTI                      [CP=0x1234][SP=0xff][S=NV-BDIZC][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_rti_interrupt_sequence() {
+        // This test verifies RTI works correctly after an interrupt sequence
+        let cpu_instruction =
+            CPUInstruction::new(0x8000, 0x40, "RTI", AddressingMode::Implied, rti);
+        let (mut memory, mut registers) = get_stuff(0x8000, vec![0x40]);
+        
+        // Simulate interrupt sequence:
+        // 1. Push return address $1234
+        // 2. Push processor status with I flag set
+        registers.command_pointer = 0x1234;
+        registers.set_i_flag(true);
+        let status = registers.get_status_register();
+        
+        // Stack should contain status then return address
+        memory.write(STACK_BASE_ADDR + 0xfd, &[status, 0x34, 0x12]).unwrap();
+        registers.stack_pointer = 0xfc;
+        
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+            
+        assert_eq!(0x1234, registers.command_pointer, "Should restore exact interrupt return address");
+        assert!(registers.i_flag_is_set(), "Should restore I flag from interrupt");
+        assert_eq!(6, log_line.cycles, "RTI should take 6 cycles");
+        assert_eq!("#0x8000: (40)          RTI                      [CP=0x1234][SP=0xff][S=nv-BdIzc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/rts.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/rts.rs
@@ -17,7 +17,12 @@ pub fn rts(
     Ok(LogLine::new(
         cpu_instruction,
         resolution,
-        format!("[CP=0x{:04X}]", registers.command_pointer),
+        format!(
+            "[CP=0x{:04X}][SP=0x{:02x}][S={}]",
+            registers.command_pointer,
+            registers.stack_pointer,
+            registers.format_status()
+        ),
     ))
 }
 
@@ -30,15 +35,46 @@ mod tests {
     #[test]
     fn test_rts() {
         let cpu_instruction =
-            CPUInstruction::new(0x8000, 0xca, "RTS", AddressingMode::Implied, rts);
-        let (mut memory, mut registers) = get_stuff(0x8000, vec![0x00]);
+            CPUInstruction::new(0x8000, 0x60, "RTS", AddressingMode::Implied, rts);
+        let (mut memory, mut registers) = get_stuff(0x8000, vec![0x60]);
         memory.write(STACK_BASE_ADDR + 0xfe, &[0x09, 0x10]).unwrap();
         registers.stack_pointer = 0xfd;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("RTS".to_owned(), log_line.mnemonic);
-        assert_eq!(0x100a, registers.command_pointer);
+        assert_eq!(0x100a, registers.command_pointer); // Return address + 1
         assert_eq!(0xff, registers.stack_pointer);
+        assert_eq!(6, log_line.cycles); // RTS always takes 6 cycles
+        assert_eq!("#0x8000: (60)          RTS                      [CP=0x100A][SP=0xff][S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_rts_with_jsr() {
+        // First do JSR
+        let jsr_instruction = CPUInstruction::new(
+            0x1000,
+            0x20,
+            "JSR",
+            AddressingMode::Absolute([0x0a, 0x20]),
+            jsr,
+        );
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x20, 0x0a, 0x20]);
+        registers.stack_pointer = 0xff;
+        let _jsr_log = jsr_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+
+        // Then do RTS
+        let rts_instruction =
+            CPUInstruction::new(0x200a, 0x60, "RTS", AddressingMode::Implied, rts);
+        let log_line = rts_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        
+        assert_eq!(0x1003, registers.command_pointer); // Original JSR location + 3
+        assert_eq!(0xff, registers.stack_pointer); // Stack pointer restored
+        assert_eq!(6, log_line.cycles); // RTS always takes 6 cycles
+        assert_eq!("#0x200A: (60)          RTS                      [CP=0x1003][SP=0xff][S=nv-Bdizc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/sec.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/sec.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_sec() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "SEC", AddressingMode::Implied, sec);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x38, "SEC", AddressingMode::Implied, sec);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x38]);
         registers.set_c_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("SEC".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(registers.c_flag_is_set());
+        assert_eq!(2, log_line.cycles); // SEC takes 2 cycles
+        assert_eq!("#0x1000: (38)          SEC                      [S=nv-BdizC][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/sed.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/sed.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_sed() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "SED", AddressingMode::Implied, sed);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xF8, "SED", AddressingMode::Implied, sed);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xF8]);
         registers.set_d_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("SED".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(registers.d_flag_is_set());
+        assert_eq!(2, log_line.cycles); // SED takes 2 cycles
+        assert_eq!("#0x1000: (f8)          SED                      [S=nv-BDizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/sei.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/sei.rs
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn test_sei() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "SEI", AddressingMode::Implied, sei);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x78, "SEI", AddressingMode::Implied, sei);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x78]);
         registers.set_i_flag(false);
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -37,5 +37,7 @@ mod tests {
         assert_eq!("SEI".to_owned(), log_line.mnemonic);
         assert_eq!(0x1001, registers.command_pointer);
         assert!(registers.i_flag_is_set());
+        assert_eq!(2, log_line.cycles); // SEI takes 2 cycles
+        assert_eq!("#0x1000: (78)          SEI                      [S=nv-BdIzc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/smb.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/smb.rs
@@ -13,6 +13,7 @@ pub fn smb(
         .target_address
         .expect("SMB expects an operand, crashing the application");
     let byte = memory.read(addr, 1)?[0];
+
     let mut bit = 0b00000001;
     (0..(cpu_instruction.opcode >> 4) - 8).for_each(|_| bit <<= 1);
     let byte = byte | bit;
@@ -37,6 +38,7 @@ mod tests {
         let cpu_instruction =
             CPUInstruction::new(0x1000, 0x87, "SMB0", AddressingMode::ZeroPage([0x0a]), smb);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0x87, 0x0a]);
+        memory.write(0x0a, &[0x00]).unwrap();
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
@@ -47,10 +49,8 @@ mod tests {
         assert!(!registers.c_flag_is_set());
         assert!(!registers.v_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (87 0a)       SMB0 $0a      (#0x000A)  (0x01)"),
-            format!("{}", log_line)
-        );
+        assert_eq!(5, log_line.cycles);
+        assert_eq!("#0x1000: (87 0a)       SMB0 $0a      (#0x000A)  (0x01)[5]", log_line.to_string());
     }
 
     #[test]
@@ -58,6 +58,7 @@ mod tests {
         let cpu_instruction =
             CPUInstruction::new(0x1000, 0xf7, "SMB7", AddressingMode::ZeroPage([0x0a]), smb);
         let (mut memory, mut registers) = get_stuff(0x1000, vec![0xf7, 0x0a]);
+        memory.write(0x0a, &[0x00]).unwrap();
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
@@ -68,9 +69,7 @@ mod tests {
         assert!(!registers.c_flag_is_set());
         assert!(!registers.v_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
-        assert_eq!(
-            format!("#0x1000: (f7 0a)       SMB7 $0a      (#0x000A)  (0x80)"),
-            format!("{}", log_line)
-        );
+        assert_eq!(5, log_line.cycles);
+        assert_eq!("#0x1000: (f7 0a)       SMB7 $0a      (#0x000A)  (0x80)[5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/sta.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/sta.rs
@@ -13,6 +13,8 @@ pub fn sta(
         .target_address
         .expect("STA must have operands, crashing the application");
 
+    // No cycle adjustments needed - table values are complete for write operations
+
     memory.write(target_address, &[registers.accumulator])?;
     registers.command_pointer += 1 + resolution.operands.len();
 
@@ -29,10 +31,10 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_sta() {
+    fn test_sta_zero_page() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "STA", AddressingMode::ZeroPage([0x0a]), sta);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xa9, 0x0a]);
+            CPUInstruction::new(0x1000, 0x85, "STA", AddressingMode::ZeroPage([0x0a]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x85, 0x0a]);
         registers.accumulator = 0x10;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -40,5 +42,118 @@ mod tests {
         assert_eq!("STA".to_owned(), log_line.mnemonic);
         assert_eq!(0x10, memory.read(0x0a, 1).unwrap()[0]);
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(3, cpu_instruction.cycles.get());
+        assert_eq!("#0x1000: (85 0a)       STA  $0a      (#0x000A)  (0x10)[3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x8D, "STA", AddressingMode::Absolute([0x00, 0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8D, 0x00, 0x20]);
+        registers.accumulator = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x2000, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get());
+        assert_eq!("#0x1000: (8d 00 20)    STA  $2000    (#0x2000)  (0x42)[4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_zero_page_indirect() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x92, "STA", AddressingMode::ZeroPageIndirect([0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x92, 0x20]);
+        memory.write(0x20, &[0x80, 0x40]).unwrap(); // Target address is 0x4080
+        registers.accumulator = 0x37;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x37, memory.read(0x4080, 1).unwrap()[0]);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, cpu_instruction.cycles.get());
+        assert_eq!("#0x1000: (92 20)       STA  ($20)    (#0x4080)  (0x37)[5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x95, "STA", AddressingMode::ZeroPageXIndexed([0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x95, 0x20]);
+        registers.register_x = 0x05; // Write to 0x25
+        registers.accumulator = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x25, 1).unwrap()[0]);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(4, cpu_instruction.cycles.get());
+        assert_eq!("#0x1000: (95 20)       STA  $20,X    (#0x0025)  (0x42)[4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_absolute_y() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x99, "STA", AddressingMode::AbsoluteYIndexed([0x00, 0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x99, 0x00, 0x20]);
+        registers.register_y = 0x05; // Write to 0x2005
+        registers.accumulator = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x2005, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, cpu_instruction.cycles.get());
+        assert_eq!("#0x1000: (99 00 20)    STA  $2000,Y  (#0x2005)  (0x42)[5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_absolute_y_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x99, "STA", AddressingMode::AbsoluteYIndexed([0xFB, 0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x99, 0xFB, 0x20]);
+        registers.register_y = 0x05; // Write to 0x2100 (page cross)
+        registers.accumulator = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x2100, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, cpu_instruction.cycles.get()); // Write operations always take 5 cycles, no page cross penalty
+        assert_eq!("#0x1000: (99 fb 20)    STA  $20FB,Y  (#0x2100)  (0x42)[5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_absolute_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x9D, "STA", AddressingMode::AbsoluteXIndexed([0x00, 0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9D, 0x00, 0x20]);
+        registers.register_x = 0x05; // Write to 0x2005
+        registers.accumulator = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x2005, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, cpu_instruction.cycles.get()); // Absolute indexed write: 5 cycles
+        assert_eq!("#0x1000: (9d 00 20)    STA  $2000,X  (#0x2005)  (0x42)[5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sta_absolute_x_page_cross() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x9D, "STA", AddressingMode::AbsoluteXIndexed([0xFB, 0x20]), sta);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9D, 0xFB, 0x20]);
+        registers.register_x = 0x05; // Write to 0x2100 (page cross)
+        registers.accumulator = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x2100, 1).unwrap()[0]);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(5, cpu_instruction.cycles.get()); // Write operations always take 5 cycles, no page cross penalty
+        assert_eq!("#0x1000: (9d fb 20)    STA  $20FB,X  (#0x2100)  (0x42)[5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/stp.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/stp.rs
@@ -9,7 +9,11 @@ pub fn stp(
         cpu_instruction
             .addressing_mode
             .solve(registers.command_pointer, memory, registers)?;
-    Ok(LogLine::new(cpu_instruction, resolution, String::new()))
+    Ok(LogLine::new(
+        cpu_instruction,
+        resolution,
+        format!("[S={}]", registers.format_status())
+    ))
 }
 
 #[cfg(test)]
@@ -27,5 +31,7 @@ mod tests {
             .unwrap();
         assert_eq!("STP".to_owned(), log_line.mnemonic);
         assert_eq!(0x1000, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // STP: 3 cycles
+        assert_eq!("#0x1000: (db)          STP                      [S=nv-Bdizc][3]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/sty.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/sty.rs
@@ -11,7 +11,7 @@ pub fn sty(
             .solve(registers.command_pointer, memory, registers)?;
     let target_address = resolution
         .target_address
-        .expect("STY must have operands, crashing the application");
+        .expect("STY instruction must have operands, crashing the application");
 
     memory.write(target_address, &[registers.register_y])?;
     registers.command_pointer += 1 + resolution.operands.len();
@@ -19,7 +19,11 @@ pub fn sty(
     Ok(LogLine::new(
         cpu_instruction,
         resolution,
-        format!("(0x{:02x})", registers.register_y),
+        format!(
+            "0x{:02x}[S={}]",
+            registers.register_y,
+            registers.format_status()
+        ),
     ))
 }
 
@@ -29,16 +33,47 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_sty() {
+    fn test_sty_zero_page() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "STY", AddressingMode::ZeroPage([0x0a]), sty);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x0a, 0x02]);
-        registers.register_y = 0x28;
+            CPUInstruction::new(0x1000, 0x84, "STY", AddressingMode::ZeroPage([0x44]), sty);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x84, 0x44]);
+        registers.register_y = 0x42;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("STY".to_owned(), log_line.mnemonic);
-        assert_eq!(0x28, memory.read(0x0a, 1).unwrap()[0]);
+        assert_eq!(0x42, memory.read(0x44, 1).unwrap()[0]);
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (84 44)       STY  $44      (#0x0044)  0x42[S=nv-Bdizc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sty_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x94, "STY", AddressingMode::ZeroPageXIndexed([0x20]), sty);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x94, 0x20]);
+        registers.register_y = 0x42;
+        registers.register_x = 0x05; // Target address will be $25
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x25, 1).unwrap()[0]);
+        assert_eq!(4, log_line.cycles); // Zero Page,X: 4 cycles
+        assert_eq!("#0x1000: (94 20)       STY  $20,X    (#0x0025)  0x42[S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_sty_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x8C, "STY", AddressingMode::Absolute([0x00, 0x44]), sty);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8C, 0x00, 0x44]);
+        registers.register_y = 0x42;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x42, memory.read(0x4400, 1).unwrap()[0]);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (8c 00 44)    STY  $4400    (#0x4400)  0x42[S=nv-Bdizc][4]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/stz.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/stz.rs
@@ -11,12 +11,19 @@ pub fn stz(
             .solve(registers.command_pointer, memory, registers)?;
     let target_address = resolution
         .target_address
-        .expect("STZ must have operands, crashing the application");
+        .expect("STZ instruction must have operands, crashing the application");
 
     memory.write(target_address, &[0x00])?;
     registers.command_pointer += 1 + resolution.operands.len();
 
-    Ok(LogLine::new(cpu_instruction, resolution, String::new()))
+    Ok(LogLine::new(
+        cpu_instruction,
+        resolution,
+        format!(
+            "0x00[S={}]",
+            registers.format_status()
+        ),
+    ))
 }
 
 #[cfg(test)]
@@ -25,20 +32,62 @@ mod tests {
     use crate::cpu_instruction::cpu_instruction::tests::get_stuff;
 
     #[test]
-    fn test_stz() {
-        let cpu_instruction = CPUInstruction::new(
-            0x1000,
-            0xca,
-            "STZ",
-            AddressingMode::Absolute([0x00, 0x10]),
-            stz,
-        );
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x4c, 0x00, 0x10]);
+    fn test_stz_zero_page() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x64, "STZ", AddressingMode::ZeroPage([0x44]), stz);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x64, 0x44]);
+        memory.write(0x44, &[0x42]).unwrap(); // Write non-zero value first
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!("STZ".to_owned(), log_line.mnemonic);
-        assert_eq!(0x00, memory.read(0x1000, 1).unwrap()[0]);
-        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(0x00, memory.read(0x44, 1).unwrap()[0]);
+        assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(3, log_line.cycles); // Zero Page: 3 cycles
+        assert_eq!("#0x1000: (64 44)       STZ  $44      (#0x0044)  0x00[S=nv-Bdizc][3]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_stz_zero_page_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x74, "STZ", AddressingMode::ZeroPageXIndexed([0x20]), stz);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x74, 0x20]);
+        registers.register_x = 0x05; // Target address will be $25
+        memory.write(0x25, &[0x42]).unwrap(); // Write non-zero value first
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x00, memory.read(0x25, 1).unwrap()[0]);
+        assert_eq!(4, log_line.cycles); // Zero Page,X: 4 cycles
+        assert_eq!("#0x1000: (74 20)       STZ  $20,X    (#0x0025)  0x00[S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_stz_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x9C, "STZ", AddressingMode::Absolute([0x00, 0x44]), stz);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9C, 0x00, 0x44]);
+        memory.write(0x4400, &[0x42]).unwrap(); // Write non-zero value first
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x00, memory.read(0x4400, 1).unwrap()[0]);
+        assert_eq!(4, log_line.cycles); // Absolute: 4 cycles
+        assert_eq!("#0x1000: (9c 00 44)    STZ  $4400    (#0x4400)  0x00[S=nv-Bdizc][4]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_stz_absolute_x() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x9E, "STZ", AddressingMode::AbsoluteXIndexed([0x00, 0x44]), stz);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9E, 0x00, 0x44]);
+        registers.register_x = 0x05; // Target address will be $4405
+        memory.write(0x4405, &[0x42]).unwrap(); // Write non-zero value first
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x00, memory.read(0x4405, 1).unwrap()[0]);
+        assert_eq!(5, log_line.cycles); // Absolute,X: 5 cycles
+        assert_eq!("#0x1000: (9e 00 44)    STZ  $4400,X  (#0x4405)  0x00[S=nv-Bdizc][5]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/tax.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/tax.rs
@@ -34,8 +34,8 @@ mod tests {
     #[test]
     fn test_tax() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TAX", AddressingMode::Implied, tax);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xAA, "TAX", AddressingMode::Implied, tax);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xAA]);
         registers.accumulator = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -45,35 +45,41 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // TAX takes 2 cycles
+        assert_eq!("#0x1000: (aa)          TAX                      [X=0x28][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_tax_with_z_flag() {
+    fn test_tax_with_zero_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TAX", AddressingMode::Implied, tax);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
-        registers.register_x = 0x28;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xAA, "TAX", AddressingMode::Implied, tax);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xAA]);
+        registers.accumulator = 0x00;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_x);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (aa)          TAX                      [X=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_tax_with_n_flag() {
+    fn test_tax_with_negative_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TAX", AddressingMode::Implied, tax);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
-        registers.accumulator = 0xf8;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xAA, "TAX", AddressingMode::Implied, tax);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xAA]);
+        registers.accumulator = 0xF8;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xf8, registers.register_x);
+        assert_eq!(0xF8, registers.register_x);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (aa)          TAX                      [X=0xf8][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/tay.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/tay.rs
@@ -34,8 +34,8 @@ mod tests {
     #[test]
     fn test_tay() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TAY", AddressingMode::Implied, tay);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xA8, "TAY", AddressingMode::Implied, tay);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA8]);
         registers.accumulator = 0x28;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -45,35 +45,41 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // TAY takes 2 cycles
+        assert_eq!("#0x1000: (a8)          TAY                      [Y=0x28][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_tay_with_z_flag() {
+    fn test_tay_with_zero_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TAY", AddressingMode::Implied, tay);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
-        registers.register_y = 0x28;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xA8, "TAY", AddressingMode::Implied, tay);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA8]);
+        registers.accumulator = 0x00;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_y);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (a8)          TAY                      [Y=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 
     #[test]
-    fn test_tay_with_n_flag() {
+    fn test_tay_with_negative_result() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TAY", AddressingMode::Implied, tay);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
-        registers.accumulator = 0xf8;
-        let _log_line = cpu_instruction
+            CPUInstruction::new(0x1000, 0xA8, "TAY", AddressingMode::Implied, tay);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xA8]);
+        registers.accumulator = 0xF8;
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
-        assert_eq!(0xf8, registers.register_y);
+        assert_eq!(0xF8, registers.register_y);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (a8)          TAY                      [Y=0xf8][S=Nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/trb.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/trb.rs
@@ -39,10 +39,10 @@ mod tests {
      * Examples come from http://www.6502.org/tutorials/65c02opcodes.html
      */
     #[test]
-    fn test_trb() {
+    fn test_trb_zero_page() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TRB", AddressingMode::ZeroPage([0x00]), trb);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x00, 0x02]);
+            CPUInstruction::new(0x1000, 0x14, "TRB", AddressingMode::ZeroPage([0x00]), trb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x14, 0x00]);
         memory.write(0x00, &[0xa6]).unwrap();
         registers.accumulator = 0x33;
         let log_line = cpu_instruction
@@ -53,21 +53,62 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert_eq!(0x33, registers.accumulator);
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // Zero Page: 5 cycles
+        assert_eq!("#0x1000: (14 00)       TRB  $00      (#0x0000)  (0x84)[S=nv-Bdizc][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_trb_with_z_flag() {
+    fn test_trb_zero_page_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TRB", AddressingMode::ZeroPage([0x00]), trb);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x00, 0x02]);
+            CPUInstruction::new(0x1000, 0x14, "TRB", AddressingMode::ZeroPage([0x00]), trb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x14, 0x00]);
         memory.write(0x00, &[0xa6]).unwrap();
         registers.accumulator = 0x41;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0xa6, memory.read(0x00, 1).unwrap()[0]);
         assert!(registers.z_flag_is_set());
         assert_eq!(0x41, registers.accumulator);
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles);
+        assert_eq!("#0x1000: (14 00)       TRB  $00      (#0x0000)  (0xa6)[S=nv-BdiZc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_trb_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x1C, "TRB", AddressingMode::Absolute([0x00, 0x20]), trb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1C, 0x00, 0x20]);
+        memory.write(0x2000, &[0xa6]).unwrap();
+        registers.accumulator = 0x33;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("TRB".to_owned(), log_line.mnemonic);
+        assert_eq!(0x84, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert_eq!(0x33, registers.accumulator);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (1c 00 20)    TRB  $2000    (#0x2000)  (0x84)[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_trb_absolute_with_z_flag() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x1C, "TRB", AddressingMode::Absolute([0x00, 0x20]), trb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x1C, 0x00, 0x20]);
+        memory.write(0x2000, &[0xa6]).unwrap();
+        registers.accumulator = 0x41;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0xa6, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(registers.z_flag_is_set());
+        assert_eq!(0x41, registers.accumulator);
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles);
+        assert_eq!("#0x1000: (1c 00 20)    TRB  $2000    (#0x2000)  (0xa6)[S=nv-BdiZc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/tsb.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/tsb.rs
@@ -35,10 +35,10 @@ mod tests {
      * Examples come from http://www.6502.org/tutorials/65c02opcodes.html
      */
     #[test]
-    fn test_tsb() {
+    fn test_tsb_zero_page() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TSB", AddressingMode::ZeroPage([0x0a]), tsb);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x04, "TSB", AddressingMode::ZeroPage([0x0a]), tsb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x04, 0x0a]);
         memory.write(0x0a, &[0xa6]).unwrap();
         registers.accumulator = 0x33;
         let log_line = cpu_instruction
@@ -48,20 +48,59 @@ mod tests {
         assert_eq!(0xb7, memory.read(0x0a, 1).unwrap()[0]);
         assert!(!registers.z_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles); // Zero Page: 5 cycles
+        assert_eq!("#0x1000: (04 0a)       TSB  $0a      (#0x000A)  (0xb7)[S=nv-Bdizc][5]", log_line.to_string());
     }
 
     #[test]
-    fn test_tsb_no_z() {
+    fn test_tsb_zero_page_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TSB", AddressingMode::ZeroPage([0x0a]), tsb);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x04, "TSB", AddressingMode::ZeroPage([0x0a]), tsb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x04, 0x0a]);
         memory.write(0x0a, &[0xa6]).unwrap();
         registers.accumulator = 0x41;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0xe7, memory.read(0x0a, 1).unwrap()[0]);
         assert!(registers.z_flag_is_set());
         assert_eq!(0x1002, registers.command_pointer);
+        assert_eq!(5, log_line.cycles);
+        assert_eq!("#0x1000: (04 0a)       TSB  $0a      (#0x000A)  (0xe7)[S=nv-BdiZc][5]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_tsb_absolute() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x0C, "TSB", AddressingMode::Absolute([0x00, 0x20]), tsb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0C, 0x00, 0x20]);
+        memory.write(0x2000, &[0xa6]).unwrap();
+        registers.accumulator = 0x33;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!("TSB".to_owned(), log_line.mnemonic);
+        assert_eq!(0xb7, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(!registers.z_flag_is_set());
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles); // Absolute: 6 cycles
+        assert_eq!("#0x1000: (0c 00 20)    TSB  $2000    (#0x2000)  (0xb7)[S=nv-Bdizc][6]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_tsb_absolute_with_z_flag() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x0C, "TSB", AddressingMode::Absolute([0x00, 0x20]), tsb);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x0C, 0x00, 0x20]);
+        memory.write(0x2000, &[0xa6]).unwrap();
+        registers.accumulator = 0x41;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0xe7, memory.read(0x2000, 1).unwrap()[0]);
+        assert!(registers.z_flag_is_set());
+        assert_eq!(0x1003, registers.command_pointer);
+        assert_eq!(6, log_line.cycles);
+        assert_eq!("#0x1000: (0c 00 20)    TSB  $2000    (#0x2000)  (0xe7)[S=nv-BdiZc][6]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/tsx.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/tsx.rs
@@ -34,8 +34,8 @@ mod tests {
     #[test]
     fn test_tsx() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TSX", AddressingMode::Implied, tsx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a]);
+            CPUInstruction::new(0x1000, 0xBA, "TSX", AddressingMode::Implied, tsx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBA]);
         registers.stack_pointer = 0x7e;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -45,35 +45,41 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // TSX takes 2 cycles
+        assert_eq!("#0x1000: (ba)          TSX                      [X=0x7e][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_tsx_with_n_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "tsx", AddressingMode::Implied, tsx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xBA, "TSX", AddressingMode::Implied, tsx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBA]);
         registers.stack_pointer = 0xfe;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0xfe, registers.register_x);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (ba)          TSX                      [X=0xfe][S=Nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_tsx_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "tsx", AddressingMode::Implied, tsx);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0xBA, "TSX", AddressingMode::Implied, tsx);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0xBA]);
         registers.stack_pointer = 0x00;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.register_x);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (ba)          TSX                      [X=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/txa.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/txa.rs
@@ -34,8 +34,8 @@ mod tests {
     #[test]
     fn test_txa() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TXA", AddressingMode::Implied, txa);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a]);
+            CPUInstruction::new(0x1000, 0x8A, "TXA", AddressingMode::Implied, txa);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8A]);
         registers.register_x = 0x43;
         registers.accumulator = 0x0a;
         let log_line = cpu_instruction
@@ -46,38 +46,44 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (8a)          TXA                      [A=0x43][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_txa_with_n_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TXA", AddressingMode::Implied, txa);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x8A, "TXA", AddressingMode::Implied, txa);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8A]);
         registers.set_n_flag(false);
         registers.register_x = 0x80;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x80, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (8a)          TXA                      [A=0x80][S=Nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_txa_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TXA", AddressingMode::Implied, txa);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x8A, "TXA", AddressingMode::Implied, txa);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8A]);
         registers.set_z_flag(false);
         registers.register_x = 0x00;
         registers.accumulator = 0x0a;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (8a)          TXA                      [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/txs.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/txs.rs
@@ -32,8 +32,8 @@ mod tests {
     #[test]
     fn test_txs() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TXS", AddressingMode::Implied, txs);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a]);
+            CPUInstruction::new(0x1000, 0x9A, "TXS", AddressingMode::Implied, txs);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9A]);
         registers.register_x = 0x83;
         let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
@@ -41,5 +41,37 @@ mod tests {
         assert_eq!("TXS".to_owned(), log_line.mnemonic);
         assert_eq!(0x83, registers.stack_pointer);
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles); // TXS takes 2 cycles
+        assert_eq!("#0x1000: (9a)          TXS                      [SP=0x83][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_txs_with_zero() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x9A, "TXS", AddressingMode::Implied, txs);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9A]);
+        registers.register_x = 0x00;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0x00, registers.stack_pointer);
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (9a)          TXS                      [SP=0x00][S=nv-Bdizc][2]", log_line.to_string());
+    }
+
+    #[test]
+    fn test_txs_with_negative() {
+        let cpu_instruction =
+            CPUInstruction::new(0x1000, 0x9A, "TXS", AddressingMode::Implied, txs);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x9A]);
+        registers.register_x = 0xFF;
+        let log_line = cpu_instruction
+            .execute(&mut memory, &mut registers)
+            .unwrap();
+        assert_eq!(0xFF, registers.stack_pointer);
+        assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (9a)          TXS                      [SP=0xff][S=nv-Bdizc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/cpu_instruction/microcode/tya.rs
+++ b/soft65c02_lib/src/cpu_instruction/microcode/tya.rs
@@ -34,8 +34,8 @@ mod tests {
     #[test]
     fn test_tya() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TYA", AddressingMode::Implied, tya);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a]);
+            CPUInstruction::new(0x1000, 0x98, "TYA", AddressingMode::Implied, tya);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x98]);
         registers.register_y = 0x43;
         registers.accumulator = 0x0a;
         let log_line = cpu_instruction
@@ -46,38 +46,44 @@ mod tests {
         assert!(!registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (98)          TYA                      [A=0x43][S=nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_tya_with_n_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TYA", AddressingMode::Implied, tya);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x98, "TYA", AddressingMode::Implied, tya);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x98]);
         registers.set_n_flag(false);
         registers.register_y = 0x80;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x80, registers.accumulator);
         assert!(!registers.z_flag_is_set());
         assert!(registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (98)          TYA                      [A=0x80][S=Nv-Bdizc][2]", log_line.to_string());
     }
 
     #[test]
     fn test_tya_with_z_flag() {
         let cpu_instruction =
-            CPUInstruction::new(0x1000, 0xca, "TYA", AddressingMode::Implied, tya);
-        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x8a, 0x0a, 0x02]);
+            CPUInstruction::new(0x1000, 0x98, "TYA", AddressingMode::Implied, tya);
+        let (mut memory, mut registers) = get_stuff(0x1000, vec![0x98]);
         registers.set_z_flag(false);
         registers.register_y = 0x00;
         registers.accumulator = 0x0a;
-        let _log_line = cpu_instruction
+        let log_line = cpu_instruction
             .execute(&mut memory, &mut registers)
             .unwrap();
         assert_eq!(0x00, registers.accumulator);
         assert!(registers.z_flag_is_set());
         assert!(!registers.n_flag_is_set());
         assert_eq!(0x1001, registers.command_pointer);
+        assert_eq!(2, log_line.cycles);
+        assert_eq!("#0x1000: (98)          TYA                      [A=0x00][S=nv-BdiZc][2]", log_line.to_string());
     }
 }

--- a/soft65c02_lib/src/registers.rs
+++ b/soft65c02_lib/src/registers.rs
@@ -34,6 +34,7 @@ pub struct Registers {
     status_register: u8,
     pub command_pointer: usize,
     pub stack_pointer: u8,
+    pub cycle_count: u64,
 }
 
 impl Registers {
@@ -45,6 +46,7 @@ impl Registers {
             status_register: (random::<u8>() | 0b00111100) & 0b11110111, // 0bXX1101XX
             command_pointer: init_address,
             stack_pointer: random::<u8>(),
+            cycle_count: 0,
         }
     }
 
@@ -62,6 +64,7 @@ impl Registers {
         self.status_register = 0b00110000;
         self.command_pointer = init_address;
         self.stack_pointer = 0xff;
+        self.cycle_count = 0;
     }
 
     pub fn get_status_register(&self) -> u8 {
@@ -172,6 +175,10 @@ impl Registers {
             if self.z_flag_is_set() { "Z" } else { "z" },
             if self.c_flag_is_set() { "C" } else { "c" },
         )
+    }
+
+    pub fn add_cycles(&mut self, cycles: u8) {
+        self.cycle_count += cycles as u64;
     }
 }
 

--- a/soft65c02_lib/tests/simulator.rs
+++ b/soft65c02_lib/tests/simulator.rs
@@ -29,16 +29,16 @@ fn execute_program() {
     let mut registers = Registers::new_initialized(init_vector);
     let loglines = execute(&mut memory, &mut registers).unwrap();
     let expected_output: Vec<&str> = vec![
-        "#0x0800: (a9 c0)       LDA  #$c0     (#0x0801)  [A=0xc0][S=Nv-Bdizc]",
-        "#0x0802: (aa)          TAX                      [X=0xc0][S=Nv-Bdizc]",
-        "#0x0803: (e8)          INX                      [X=0xc1][S=Nv-Bdizc]",
-        "#0x0804: (69 14)       ADC  #$14     (#0x0805)  (0x14)[A=0xd4][S=Nv-Bdizc]",
-        "#0x0806: (00)          BRK                      [CP=0x8000][SP=0xfc]",
-        "#0x8000: (95 20)       STA  $20,X    (#0x00E1)  (0xd4)",
-        "#0x8002: (40)          RTI                      [CP=0x0808][SP=0xff][S=Nv-Bdizc]",
-        "#0x0808: (d5 20)       CMP  $20,X    (#0x00E1)  (0xd4)[A=0xd4][S=nv-BdiZC]",
-        "#0x080A: (d0 fe)       BNE  $080A               [CP=0x080C]",
-        "#0x080C: (db)          STP",
+        "#0x0800: (a9 c0)       LDA  #$c0     (#0x0801)  [A=0xc0][S=Nv-Bdizc][2]",
+        "#0x0802: (aa)          TAX                      [X=0xc0][S=Nv-Bdizc][2]",
+        "#0x0803: (e8)          INX                      [X=0xc1][S=Nv-Bdizc][2]",
+        "#0x0804: (69 14)       ADC  #$14     (#0x0805)  (0x14)[A=0xd4][S=Nv-Bdizc][2]",
+        "#0x0806: (00)          BRK                      [CP=0x8000][SP=0xfc][S=Nv-BdIzc][7]",
+        "#0x8000: (95 20)       STA  $20,X    (#0x00E1)  (0xd4)[4]",
+        "#0x8002: (40)          RTI                      [CP=0x0808][SP=0xff][S=Nv-Bdizc][6]",
+        "#0x0808: (d5 20)       CMP  $20,X    (#0x00E1)  (0xd4)[A=0xd4][S=nv-BdiZC][4]",
+        "#0x080A: (d0 fe)       BNE  $080A               [CP=0x080C][2]",
+        "#0x080C: (db)          STP                      [S=nv-BdiZC][3]",
     ];
     loglines.iter().enumerate().for_each(|(i, line)| {
         assert_eq!(

--- a/soft65c02_tester/rules.pest
+++ b/soft65c02_tester/rules.pest
@@ -16,10 +16,11 @@ registers_action = _{ registers_set | registers_flush }
 registers_flush = { ^"flush" }
 registers_set = { ^"set" ~ register_assignment }
 
-register_assignment = { assignment8 | assignment16 }
+register_assignment = { assignment8 | assignment16 | assignment_cycle }
 
 assignment8 = _{ register8 ~ "=" ~ (value8 | memory_address) }
 assignment16 = _{ register16 ~ "=" ~ (value16 | memory_address) }
+assignment_cycle = _{ register_cycle ~ "=" ~ value16 }
 
 memory_instruction = { ^"memory" ~ memory_action }
 memory_action = _{ memory_load | memory_write | memory_flush }
@@ -38,15 +39,17 @@ assert_instruction = { ^"assert" ~ boolean_condition ~ "$$" ~ description ~ "$$"
 boolean_condition = { boolean | memory_sequence | comparison }
 
 boolean = { ^"true" | ^"false" }
-comparison = { comparison16 | comparison8 }
+comparison = { comparison16 | comparison8 | comparison_cycle }
 comparison16 = _{ location16 ~ standard_operator ~ value16 }
 comparison8 = _{ location8 ~ standard_operator ~ value8 }
+comparison_cycle = _{ location_cycle ~ standard_operator ~ value16 }
 memory_sequence = { memory_address ~ "~" ~ (bytes_list | string_literal) }
 string_literal = { "\"" ~ string_char* ~ "\"" }
 string_char = { !("\"" | "\\") ~ ASCII | "\\" ~ ("\"" | "\\" | "n" | "r" | "t" | "0") }
 
 location16 = _{ register16 }
 location8 = _{ memory_address | register8 }
+location_cycle = _{ register_cycle }
 
 memory_address = { hex_address | symbol_reference }
 hex_address = { "#0x" ~ ASCII_HEX_DIGIT{4} }
@@ -55,6 +58,7 @@ symbol_name = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 register16 = { "CP" }
 register8 = { "A" | "X" | "Y" | "SP" | "S" }
+register_cycle = { "cycle_count" }
 value16 = { "0x" ~ ASCII_HEX_DIGIT{4} }
 value8 = { "0x" ~ ASCII_HEX_DIGIT{2} | "0b" ~ ASCII_BIN_DIGIT{8} }
 bytes_list = { ^"0x(" ~ bytes ~ ")" }

--- a/soft65c02_tester/src/commands.rs
+++ b/soft65c02_tester/src/commands.rs
@@ -331,7 +331,7 @@ mod run_command_tests {
         memory.write(0x1000, &[0xd0, 0b11111110]).unwrap(); // BNE -1
         let token = command.execute(&mut registers, &mut memory, &mut None).unwrap();
 
-        assert!(matches!(token, OutputToken::Run { loglines } if loglines.len() == 1))
+        assert!(matches!(token, OutputToken::Run { loglines } if loglines.len() == 1));
     }
 }
 

--- a/soft65c02_tester/src/displayer.rs
+++ b/soft65c02_tester/src/displayer.rs
@@ -60,6 +60,12 @@ where
                         .collect::<Vec<_>>()
                         .join("\n");
                     content.push('\n');
+                    
+                    if loglines.len() > 1 {
+                        let total_cycles: u32 = loglines.iter().map(|l| l.cycles as u32).sum();
+                        content.push_str(&format!("🕒 Total cycles: {}\n", total_cycles));
+                    }
+                    
                     self.output.write_all(content.as_bytes())?;
                 }
                 OutputToken::Setup(lines) if self.verbose => {

--- a/soft65c02_tester/src/executor.rs
+++ b/soft65c02_tester/src/executor.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::anyhow;
 use soft65c02_lib::{Memory, Registers};
 
-use crate::{AppResult, CliCommand, CliCommandParser, Command, OutputToken, symbols::SymbolTable};
+use crate::{AppResult, CliCommand, CliCommandParser, Command, OutputToken, SymbolTable};
 
 #[derive(Debug)]
 struct ExecutionRound {

--- a/soft65c02_tester/src/lib.rs
+++ b/soft65c02_tester/src/lib.rs
@@ -11,5 +11,6 @@ pub use commands::*;
 pub use displayer::*;
 pub use executor::*;
 pub use pest_parser::CliCommandParser;
+pub use symbols::SymbolTable;
 
 pub type AppResult<T> = anyhow::Result<T>;

--- a/soft65c02_tester/src/until_condition.rs
+++ b/soft65c02_tester/src/until_condition.rs
@@ -12,6 +12,7 @@ pub enum RegisterSource {
     Status,
     StackPointer,
     CommandPointer,
+    CycleCount,
 }
 
 impl RegisterSource {
@@ -23,6 +24,7 @@ impl RegisterSource {
             Self::Status => registers.get_status_register() as usize,
             Self::StackPointer => registers.stack_pointer as usize,
             Self::CommandPointer => registers.command_pointer,
+            Self::CycleCount => registers.cycle_count as usize,
         }
     }
 }
@@ -36,6 +38,7 @@ impl fmt::Display for RegisterSource {
             Self::Status => write!(f, "S"),
             Self::StackPointer => write!(f, "SP"),
             Self::CommandPointer => write!(f, "CP"),
+            Self::CycleCount => write!(f, "cycle_count"),
         }
     }
 }
@@ -91,6 +94,12 @@ impl Assignment {
                 registers.command_pointer = val;
 
                 format!("register CP set to #0x{val:04x}")
+            }
+            RegisterSource::CycleCount => {
+                let val = self.source.get_value(registers, memory);
+                registers.cycle_count = val as u64;
+
+                format!("cycle_count set to {val}")
             }
         };
 

--- a/soft65c02_tester/tests/test_atari.txt
+++ b/soft65c02_tester/tests/test_atari.txt
@@ -69,9 +69,8 @@ assert CP=0x0001        $$Exit function$$
 
 registers set X=0xFF
 memory write #0x02C8 0x(ff)
-run $cust_init
+run $cust_init until CP=0x200b
 assert X=0x00           $$X is set to 00$$
-run
 assert #0x02C8=0x00     $$Changes to value in X$$
 run
 assert CP=0x0001        $$Exit function$$


### PR DESCRIPTION
This is a big one! I wanted to be able to do things like

```
run until cycle_count > 0x0200
```

to allow tests to run a function, but if it goes awry, not to cause the test to hang if your code has bugs, so you can set an upper limit expectation for functions before they fail.

However, this required adding cycle timing to the instructions, and this PR allows this functionality by providing accurate cycle timings for all instructions.

I have visited and fixed every microcode function in lib, and:
- added cycle timings
- fixed the tests to use the correct opcodes (many were 0xca and copied everywhere, which gave problems with cycle tests)
- added a lot more tests to ensure every addressing mode is tested
- made the cycle timings accurate to a 65c02, including boundary checking, branching, and some of the more obscure differences between 6502 and 65c02 where i've gone with the 65c02 version
- updated all log_lines to show the cycle time at the end of the line
- updated many of the outputs for the log_lines to include additional information, e.g. showing the value of memory being AND'd, or the accumulator and the memory when using BIT so you can see what was operated on.
- Added a "Total cycles:" output if the "run" caused more than 1 statement to execute (so you can see the sum total of cycles a function took for example)

I have another 2 PRs waiting that adds to this, but wanted to get these lib-only changes approved first.

The other PRs are enhancements to the tester (adding logical "AND/OR/NOT" for any boolean condition, adding "while" loop as an alternate to "until", and other bits) which all benefit from this PR.

If you want to see more information, check the `documentation.md` changes, e.g. if these were the 2 instructions that ran, you'd get the following output

```
🚀 #0x2006: (a2 00)       LDX  #$00     (#0x2007)  [X=0x00][S=nv-BdiZc][2]
🚀 #0x2008: (8e c8 02)    STX  $02C8    (#0x02C8)  0x00[S=nv-BdiZc][4]
🕒 Total cycles: 6
```
showing the individual cycles at the end of the lines, and the total of the "run"
